### PR TITLE
Small fix to 1D Green's functions...

### DIFF
--- a/GreensFunction1DAbsAbs.cpp
+++ b/GreensFunction1DAbsAbs.cpp
@@ -42,7 +42,7 @@ uint GreensFunction1DAbsAbs::guess_maxi(Real const& t) const
 
     if (thr <= 0.0)
     {
-        return MAX_TERMS;
+        return static_cast<uint>(MAX_TERMS);
     }
 
     const Real max_root( sqrt(root0 * root0 - log(thr) / Dt) );
@@ -50,10 +50,10 @@ uint GreensFunction1DAbsAbs::guess_maxi(Real const& t) const
     const uint maxi(std::max( safety + 
                               static_cast<uint>
                               (max_root * L  / M_PI),
-                              MIN_TERMS )
+                              static_cast<uint>(MIN_TERMS) )
                     );
 
-    return std::min(maxi, MAX_TERMS);
+    return std::min(maxi, static_cast<uint>(MAX_TERMS) );
 }
 
 
@@ -111,7 +111,7 @@ Real GreensFunction1DAbsAbs::p_survival_table(Real t, RealVector& psurvTable) co
 
     const uint maxi( guess_maxi(t) );
     
-    if( maxi >= MAX_TERMS )
+    if( maxi >= static_cast<uint>(MAX_TERMS) )
         log_.warn("drawT: maxi was cut to MAX_TERMS for t = %.16g", t);
     
     if (psurvTable.size() < maxi)
@@ -252,7 +252,7 @@ Real GreensFunction1DAbsAbs::prob_r (Real r, Real t) const
     uint n = 0;
     do
     {
-        if (n >= MAX_TERMS )
+        if (n >= static_cast<uint>(MAX_TERMS) )
         {
             log_.warn("Too many terms for prob_r. N: %6u", n);
             break;
@@ -267,7 +267,7 @@ Real GreensFunction1DAbsAbs::prob_r (Real r, Real t) const
     }
     while (fabs(term/sum) > EPSILON*PDENS_TYPICAL ||
            fabs(prev_term/sum) > EPSILON*PDENS_TYPICAL ||
-           n < MIN_TERMS);
+           n < static_cast<uint>(MIN_TERMS) );
 
     return 2.0/L * exp(vexpo) * sum;
 }
@@ -317,7 +317,7 @@ GreensFunction1DAbsAbs::leaves(Real t) const
     uint n = 0;
     do
     {
-        if (n >= MAX_TERMS )
+        if (n >= static_cast<uint>(MAX_TERMS) )
         {
             log_.warn("Too many terms for leaves. N: %6u", n);
             break;
@@ -331,7 +331,7 @@ GreensFunction1DAbsAbs::leaves(Real t) const
     }
     while (fabs(term/sum) > EPSILON*PDENS_TYPICAL ||
            fabs(prev_term/sum) > EPSILON*PDENS_TYPICAL ||
-           n < MIN_TERMS );
+           n < static_cast<uint>(MIN_TERMS) );
 
     return 2.0 * D_L_sq * exp( vexpo ) * sum;
 }
@@ -372,7 +372,7 @@ GreensFunction1DAbsAbs::leavea(Real t) const
     Real n = 0;
     do
      {
-         if (n >= MAX_TERMS )
+         if (n >= static_cast<uint>(MAX_TERMS) )
          {
              log_.warn("Too many terms for leavea. N: %6u ", n);
              break;
@@ -386,7 +386,7 @@ GreensFunction1DAbsAbs::leavea(Real t) const
      }
      while (fabs(term/sum) > EPSILON*PDENS_TYPICAL ||
             fabs(prev_term/sum) > EPSILON*PDENS_TYPICAL ||
-            n < MIN_TERMS );
+            n < static_cast<uint>(MIN_TERMS) );
      
      return - 2.0 * D_L_sq * exp(vexpo) * sum;
 }
@@ -611,7 +611,7 @@ Real GreensFunction1DAbsAbs::p_int_r_table(Real const& r,
         create_p_int_r_Table(t, maxi, table);
     }
     
-    if( maxi >= MAX_TERMS )
+    if( maxi >= static_cast<uint>(MAX_TERMS) )
     {
         log_.warn("drawR: maxi was cut to MAX_TERMS for t = %.16g", t);
         std::cerr << dump();
@@ -620,7 +620,7 @@ Real GreensFunction1DAbsAbs::p_int_r_table(Real const& r,
 
     p = funcSum(boost::bind(&GreensFunction1DAbsAbs::p_int_r_i, 
                             this, _1, r, t, table),
-                MAX_TERMS);
+                static_cast<uint>(MAX_TERMS) );
 
     return prefac * p;
 }

--- a/GreensFunction1DAbsAbs.hpp
+++ b/GreensFunction1DAbsAbs.hpp
@@ -44,9 +44,9 @@ private:
     //E3; Is 1E3 a good measure for the probability density?!
     static const Real PDENS_TYPICAL = 1;
     // The maximum number of terms in the sum
-    static const uint MAX_TERMS = 500;
+    static const int MAX_TERMS = 500;
     // The minimum
-    static const uint MIN_TERMS = 20;
+    static const int MIN_TERMS = 20;
     // Cutoff distance: When H * sqrt(2Dt) < 1/2*L, use free greensfunction instead of absorbing.
     static const Real CUTOFF_H = 6.0;
 

--- a/GreensFunction1DAbsSinkAbs.cpp
+++ b/GreensFunction1DAbsSinkAbs.cpp
@@ -238,7 +238,7 @@ uint GreensFunction1DAbsSinkAbs::guess_maxi(Real const& t) const
 
     if (thr <= 0.0)
     {
-        return MAX_TERMS;
+        return static_cast<uint>(MAX_TERMS);
     }
 
     const Real max_root( sqrt(root0 * root0 - log(thr) / Dt) );
@@ -246,7 +246,7 @@ uint GreensFunction1DAbsSinkAbs::guess_maxi(Real const& t) const
     const uint maxi(safety + 
           static_cast<unsigned int>(max_root * ( getLr() + getLl() )  / M_PI));
 
-    return std::min(maxi, MAX_TERMS);
+    return std::min(maxi, static_cast<uint>(MAX_TERMS) );
 }
 
 
@@ -320,7 +320,7 @@ Real GreensFunction1DAbsSinkAbs::p_survival_table(Real t, RealVector& psurvTable
 
     const uint maxi( guess_maxi(t) );
     
-    if( maxi == MAX_TERMS )
+    if( maxi == static_cast<uint>(MAX_TERMS) )
         log_.info("drawT: maxi was cut to MAX_TERMS for t = %.16g", t);
         
     if (psurvTable.size() < maxi )
@@ -476,13 +476,13 @@ Real GreensFunction1DAbsSinkAbs::prob_r(Real r, Real t) const
     {   
         p = funcSum(boost::bind(&GreensFunction1DAbsSinkAbs::prob_r_r0_i, 
                                 this, _1, rr, t),
-                    MAX_TERMS);
+                    static_cast<uint>(MAX_TERMS) );
 	}
     else
     {
         p = funcSum(boost::bind(&GreensFunction1DAbsSinkAbs::prob_r_nor0_i, 
                                 this, _1, rr, t),
-                    MAX_TERMS);
+                    static_cast<uint>(MAX_TERMS) );
     }
     
     return p;
@@ -547,7 +547,7 @@ Real GreensFunction1DAbsSinkAbs::flux_tot(Real t) const
 
     p = funcSum(boost::bind(&GreensFunction1DAbsSinkAbs::flux_tot_i, 
                             this, _1, t),
-                MAX_TERMS);
+                static_cast<uint>(MAX_TERMS) );
 
     return D * p;
 }
@@ -572,7 +572,7 @@ Real GreensFunction1DAbsSinkAbs::flux_abs_Lr(Real t, uint const& maxi) const
    
     p = funcSum(boost::bind(&GreensFunction1DAbsSinkAbs::flux_abs_Lr_i, 
                             this, _1, t),
-                MAX_TERMS);
+                static_cast<uint>(MAX_TERMS) );
 
     return - D * 2 * p;
 }
@@ -605,7 +605,7 @@ Real GreensFunction1DAbsSinkAbs::flux_abs_Ll(Real t, uint const& maxi) const
 
     p = funcSum(boost::bind(&GreensFunction1DAbsSinkAbs::flux_abs_Ll_i, 
                             this, _1, t),
-                MAX_TERMS);
+                static_cast<uint>(MAX_TERMS));
     
     return 2 * D2 * p;
 }
@@ -685,7 +685,7 @@ GreensFunction1DAbsSinkAbs::drawEventType( Real rnd, Real t ) const
     /* Allready fill rootList with needed roots. */ 
     const uint maxi( guess_maxi( t ) );
 
-    if( maxi == MAX_TERMS )
+    if( maxi == static_cast<uint>(MAX_TERMS) )
         log_.info("drawEventType: maxi was cut to MAX_TERMS for t = %.16g", t);
 
     calculate_n_roots( maxi );
@@ -876,7 +876,7 @@ Real GreensFunction1DAbsSinkAbs::p_int_r_table(Real const& r,
 
     const uint maxi( guess_maxi(t) );
 
-    if( maxi == MAX_TERMS )
+    if( maxi == static_cast<uint>(MAX_TERMS) )
         log_.warn("p_int_r_table: maxi was cut to MAX_TERMS for t = %.16g"
                   , t);
    
@@ -900,7 +900,7 @@ Real GreensFunction1DAbsSinkAbs::p_int_r_table(Real const& r,
 
     p = funcSum(boost::bind(p_int_r_i, 
                             this, _1, rr, t, table),
-                MAX_TERMS);
+                static_cast<uint>(MAX_TERMS));
 
     return 2.0 * p;
 }

--- a/GreensFunction1DAbsSinkAbs.hpp
+++ b/GreensFunction1DAbsSinkAbs.hpp
@@ -42,9 +42,9 @@ private:
     // Is 1E3 a good measure for the probability density?!
     static const Real PDENS_TYPICAL = 1;
     // The maximum number of terms used in calculating the sum
-    static const uint MAX_TERMS = 500;
+    static const int MAX_TERMS = 500;
     // The minimum number of terms
-    static const uint MIN_TERMS = 20;
+    static const int MIN_TERMS = 20;
     /* Cutoff distance: When H * sqrt(2Dt) < a - r0 OR ro - sigma
        use free greensfunction instead of absorbing. */
     static const Real CUTOFF_H = 6.0;

--- a/GreensFunction1DRadAbs.cpp
+++ b/GreensFunction1DRadAbs.cpp
@@ -127,7 +127,7 @@ uint GreensFunction1DRadAbs::guess_maxi(Real const& t) const
 
     if (thr <= 0.0)
     {
-        return MAX_TERMS;
+        return static_cast<uint>(MAX_TERMS);
     }
 
     const Real max_root( sqrt(root0 * root0 - log(thr) / Dt) );
@@ -135,10 +135,10 @@ uint GreensFunction1DRadAbs::guess_maxi(Real const& t) const
     const uint maxi(std::max( safety + 
                               static_cast<uint>
                               (max_root * L  / M_PI),
-                              MIN_TERMS )
+                              static_cast<uint>(MIN_TERMS) )
                     );
 
-    return std::min(maxi, MAX_TERMS);
+    return std::min(maxi, static_cast<uint>(MAX_TERMS) );
 }
 
 
@@ -255,7 +255,7 @@ Real GreensFunction1DRadAbs::p_survival_table(Real t, RealVector& psurvTable) co
 
     const uint maxi( guess_maxi(t) );
     
-    if( maxi >= MAX_TERMS )
+    if( maxi >= static_cast<uint>(MAX_TERMS) )
         log_.warn("drawT: maxi was cut to MAX_TERMS for t = %.16g", t);
     
     if ( psurvTable.size() < maxi )
@@ -409,7 +409,7 @@ Real GreensFunction1DRadAbs::prob_r (Real r, Real t) const
     uint n = 0;
     do
     {
-        if ( n >= MAX_TERMS )
+        if ( n >= static_cast<uint>(MAX_TERMS) )
         {
             log_.warn("Too many terms needed for prob_r. N: %5u", n);
             break;
@@ -426,7 +426,7 @@ Real GreensFunction1DRadAbs::prob_r (Real r, Real t) const
     }
     while (fabs(term/sum) > EPSILON*PDENS_TYPICAL || 
            fabs(prev_term/sum) > EPSILON*PDENS_TYPICAL ||
-           n < MIN_TERMS );
+           n < static_cast<uint>(MIN_TERMS) );
 
     return 2.0*exp(vexpo)*sum;
 }
@@ -460,7 +460,7 @@ Real GreensFunction1DRadAbs::flux_tot (Real t) const
     uint n = 0;
     do
     {
-        if ( n >= MAX_TERMS )
+        if ( n >= static_cast<uint>(MAX_TERMS) )
         {
             log_.warn("Too many terms needed for flux_tot. N: %5u", n );
             break;
@@ -474,7 +474,7 @@ Real GreensFunction1DRadAbs::flux_tot (Real t) const
     }
     while (fabs(term/sum) > EPSILON*PDENS_TYPICAL ||
            fabs(prev_term/sum) > EPSILON*PDENS_TYPICAL ||
-           n < MIN_TERMS );
+           n < static_cast<uint>(MIN_TERMS) );
 
     return 2.0*D*exp(vexpo)*sum;
 }
@@ -729,7 +729,7 @@ Real GreensFunction1DRadAbs::p_int_r_table(Real const& r,
     const Real vexpo(-v*v*t/4.0/D - v*r0/2.0/D);
     const Real prefac( 2.0*exp(vexpo) );
 
-    if( maxi >= MAX_TERMS )
+    if( maxi >= static_cast<uint>(MAX_TERMS) )
     {
         log_.warn("drawR: maxi was cut to MAX_TERMS for t = %.16g", t);
         std::cerr << dump();
@@ -744,7 +744,7 @@ Real GreensFunction1DRadAbs::p_int_r_table(Real const& r,
 
     p = funcSum(boost::bind(&GreensFunction1DRadAbs::p_int_r_i, 
                             this, _1, r, t, table),
-                MAX_TERMS);
+                static_cast<uint>(MAX_TERMS) );
 
     return prefac * p;
 }

--- a/GreensFunction1DRadAbs.hpp
+++ b/GreensFunction1DRadAbs.hpp
@@ -41,9 +41,9 @@ private:
     // Is 1E3 a good measure for the probability density?!
     static const Real PDENS_TYPICAL = 1;
     // The maximum number of terms used in calculating the sum
-    static const uint MAX_TERMS = 500;
+    static const int MAX_TERMS = 500;
     // The minimum number of terms
-    static const uint MIN_TERMS = 20;
+    static const int MIN_TERMS = 20;
     /* Cutoff distance: When H * sqrt(2Dt) < a - r0 OR ro - sigma
        use free greensfunction instead of absorbing. */
     static const Real CUTOFF_H = 6.0;


### PR DESCRIPTION
...that caused import errors in _greens_functions.so on a
cluster operating system.

Casting MIN_TERMS and MAX_TERMS to unsigned int when necessary
instead of defining them as such. They are of type int now.
