### PR TITLE
Struct fu beautify

### DIFF
--- a/CuboidalRegion.hpp
+++ b/CuboidalRegion.hpp
@@ -241,41 +241,49 @@ public:
     };
     
     // *** 3 *** - Pair reactions => two origin structures
+    // First dispatch
     // Overloading get_pos_sid_pair with signature (origin_structure2, target_structure_type_id, ...)
-    virtual position_structid_pair_type get_pos_sid_pair(structure_type const& origin_structure2, structure_type_id_type const& target_sid,
+   virtual position_structid_pair_type get_pos_sid_pair(structure_type const& origin_structure2, structure_type_id_type const& target_sid, position_type const& CoM,
+                                                        length_type const& offset, length_type const& reaction_length, rng_type& rng) const
+    {   
+        // this just redirects
+        return this->get_pos_sid_pair_2o(origin_structure2, target_sid, CoM, offset, reaction_length, rng);                            
+    }
+    // The actual implementation of the first dispatch
+    virtual position_structid_pair_type get_pos_sid_pair_2o(structure_type const& origin_structure2, structure_type_id_type const& target_sid,
                                                          position_type const& CoM, length_type const& offset, length_type const& reaction_length, rng_type& rng) const
     {
-        return origin_structure2.get_pos_sid_pair_helper_two_origins(*this, target_sid, CoM, offset, reaction_length, rng);
+        return origin_structure2.get_pos_sid_pair_2o_helper(*this, target_sid, CoM, offset, reaction_length, rng);
     }
     // Second dispatch
-    virtual position_structid_pair_type get_pos_sid_pair_helper_two_origins(CuboidalRegion<traits_type> const& origin_structure1, structure_type_id_type const& target_sid,
+    virtual position_structid_pair_type get_pos_sid_pair_2o_helper(CuboidalRegion<traits_type> const& origin_structure1, structure_type_id_type const& target_sid,
                                                                             position_type const& CoM, length_type const& offset, length_type const& rl, rng_type& rng) const
     {                          
-        return this->get_pos_sid_pair_helper_two_origins_any<CuboidalRegion<traits_type> >(origin_structure1, target_sid, CoM, offset, rl, rng);
+        return this->get_pos_sid_pair_2o_helper_any<CuboidalRegion<traits_type> >(origin_structure1, target_sid, CoM, offset, rl, rng);
     }
-    virtual position_structid_pair_type get_pos_sid_pair_helper_two_origins(SphericalSurface<traits_type> const& origin_structure1, structure_type_id_type const& target_sid,
+    virtual position_structid_pair_type get_pos_sid_pair_2o_helper(SphericalSurface<traits_type> const& origin_structure1, structure_type_id_type const& target_sid,
                                                                             position_type const& CoM, length_type const& offset, length_type const& rl, rng_type& rng) const
     {                          
-        return this->get_pos_sid_pair_helper_two_origins_any<SphericalSurface<traits_type> >(origin_structure1, target_sid, CoM, offset, rl, rng);
+        return this->get_pos_sid_pair_2o_helper_any<SphericalSurface<traits_type> >(origin_structure1, target_sid, CoM, offset, rl, rng);
     }
-    virtual position_structid_pair_type get_pos_sid_pair_helper_two_origins(CylindricalSurface<traits_type> const& origin_structure1, structure_type_id_type const& target_sid,
+    virtual position_structid_pair_type get_pos_sid_pair_2o_helper(CylindricalSurface<traits_type> const& origin_structure1, structure_type_id_type const& target_sid,
                                                                             position_type const& CoM, length_type const& offset, length_type const& rl, rng_type& rng) const
     {                          
-        return this->get_pos_sid_pair_helper_two_origins_any<CylindricalSurface<traits_type> >(origin_structure1, target_sid, CoM, offset, rl, rng);
+        return this->get_pos_sid_pair_2o_helper_any<CylindricalSurface<traits_type> >(origin_structure1, target_sid, CoM, offset, rl, rng);
     }
-    virtual position_structid_pair_type get_pos_sid_pair_helper_two_origins(DiskSurface<traits_type> const& origin_structure1, structure_type_id_type const& target_sid,
+    virtual position_structid_pair_type get_pos_sid_pair_2o_helper(DiskSurface<traits_type> const& origin_structure1, structure_type_id_type const& target_sid,
                                                                             position_type const& CoM, length_type const& offset, length_type const& rl, rng_type& rng) const
     {                          
-        return this->get_pos_sid_pair_helper_two_origins_any<DiskSurface<traits_type> >(origin_structure1, target_sid, CoM, offset, rl, rng);
+        return this->get_pos_sid_pair_2o_helper_any<DiskSurface<traits_type> >(origin_structure1, target_sid, CoM, offset, rl, rng);
     }
-    virtual position_structid_pair_type get_pos_sid_pair_helper_two_origins(PlanarSurface<traits_type> const& origin_structure1, structure_type_id_type const& target_sid,
+    virtual position_structid_pair_type get_pos_sid_pair_2o_helper(PlanarSurface<traits_type> const& origin_structure1, structure_type_id_type const& target_sid,
                                                                             position_type const& CoM, length_type const& offset, length_type const& rl, rng_type& rng) const
     {                          
-        return this->get_pos_sid_pair_helper_two_origins_any<PlanarSurface<traits_type> >(origin_structure1, target_sid, CoM, offset, rl, rng);
+        return this->get_pos_sid_pair_2o_helper_any<PlanarSurface<traits_type> >(origin_structure1, target_sid, CoM, offset, rl, rng);
     }    
     // The template function that defines the actual final dispatch procedure.
     template<typename Tstruct_>
-    position_structid_pair_type get_pos_sid_pair_helper_two_origins_any(Tstruct_ const& origin_structure1, structure_type_id_type const& target_sid, position_type const& CoM,
+    position_structid_pair_type get_pos_sid_pair_2o_helper_any(Tstruct_ const& origin_structure1, structure_type_id_type const& target_sid, position_type const& CoM,
                                                                         length_type const& offset, length_type const& reaction_length, rng_type& rng) const
     {
         if( this->is_parent_of_or_has_same_sid_as(origin_structure1) && origin_structure1.has_valid_target_sid(target_sid) )

--- a/CuboidalRegion.hpp
+++ b/CuboidalRegion.hpp
@@ -242,14 +242,14 @@ public:
     
     // *** 3 *** - Pair reactions => two origin structures
     // First dispatch
-    // Overloading get_pos_sid_pair with signature (origin_structure2, target_structure_type_id, ...)
-   virtual position_structid_pair_type get_pos_sid_pair(structure_type const& origin_structure2, structure_type_id_type const& target_sid, position_type const& CoM,
-                                                        length_type const& offset, length_type const& reaction_length, rng_type& rng) const
-    {   
-        // this just redirects
-        return this->get_pos_sid_pair_2o(origin_structure2, target_sid, CoM, offset, reaction_length, rng);                            
-    }
-    // The actual implementation of the first dispatch
+//     // Overloading get_pos_sid_pair with signature (origin_structure2, target_structure_type_id, ...)
+//    virtual position_structid_pair_type get_pos_sid_pair(structure_type const& origin_structure2, structure_type_id_type const& target_sid, position_type const& CoM,
+//                                                         length_type const& offset, length_type const& reaction_length, rng_type& rng) const
+//     {   
+//         // this just redirects
+//         return this->get_pos_sid_pair_2o(origin_structure2, target_sid, CoM, offset, reaction_length, rng);                            
+//     }
+//     // The actual implementation of the first dispatch
     virtual position_structid_pair_type get_pos_sid_pair_2o(structure_type const& origin_structure2, structure_type_id_type const& target_sid,
                                                          position_type const& CoM, length_type const& offset, length_type const& reaction_length, rng_type& rng) const
     {

--- a/CylindricalSurface.hpp
+++ b/CylindricalSurface.hpp
@@ -316,41 +316,49 @@ public:
     };
     
     // *** 3 *** - Pair reactions => two origin structures
+    // First dispatch
     // Overloading get_pos_sid_pair with signature (origin_structure2, target_structure_type_id, ...)
-    virtual position_structid_pair_type get_pos_sid_pair(structure_type const& origin_structure2, structure_type_id_type const& target_sid,
+   virtual position_structid_pair_type get_pos_sid_pair(structure_type const& origin_structure2, structure_type_id_type const& target_sid, position_type const& CoM,
+                                                        length_type const& offset, length_type const& reaction_length, rng_type& rng) const
+    {   
+        // this just redirects
+        return this->get_pos_sid_pair_2o(origin_structure2, target_sid, CoM, offset, reaction_length, rng);                            
+    }
+    // The actual implementation of the first dispatch
+    virtual position_structid_pair_type get_pos_sid_pair_2o(structure_type const& origin_structure2, structure_type_id_type const& target_sid,
                                                          position_type const& CoM, length_type const& offset, length_type const& reaction_length, rng_type& rng) const
     {
-        return origin_structure2.get_pos_sid_pair_helper_two_origins(*this, target_sid, CoM, offset, reaction_length, rng);
+        return origin_structure2.get_pos_sid_pair_2o_helper(*this, target_sid, CoM, offset, reaction_length, rng);
     }
     // Second dispatch
-    virtual position_structid_pair_type get_pos_sid_pair_helper_two_origins(CuboidalRegion<traits_type> const& origin_structure1, structure_type_id_type const& target_sid,
+    virtual position_structid_pair_type get_pos_sid_pair_2o_helper(CuboidalRegion<traits_type> const& origin_structure1, structure_type_id_type const& target_sid,
                                                                             position_type const& CoM, length_type const& offset, length_type const& rl, rng_type& rng) const
     {                          
-        return this->get_pos_sid_pair_helper_two_origins_any<CuboidalRegion<traits_type> >(origin_structure1, target_sid, CoM, offset, rl, rng);
+        return this->get_pos_sid_pair_2o_helper_any<CuboidalRegion<traits_type> >(origin_structure1, target_sid, CoM, offset, rl, rng);
     }
-    virtual position_structid_pair_type get_pos_sid_pair_helper_two_origins(SphericalSurface<traits_type> const& origin_structure1, structure_type_id_type const& target_sid,
+    virtual position_structid_pair_type get_pos_sid_pair_2o_helper(SphericalSurface<traits_type> const& origin_structure1, structure_type_id_type const& target_sid,
                                                                             position_type const& CoM, length_type const& offset, length_type const& rl, rng_type& rng) const
     {                          
-        return this->get_pos_sid_pair_helper_two_origins_any<SphericalSurface<traits_type> >(origin_structure1, target_sid, CoM, offset, rl, rng);
+        return this->get_pos_sid_pair_2o_helper_any<SphericalSurface<traits_type> >(origin_structure1, target_sid, CoM, offset, rl, rng);
     }
-    virtual position_structid_pair_type get_pos_sid_pair_helper_two_origins(CylindricalSurface<traits_type> const& origin_structure1, structure_type_id_type const& target_sid,
+    virtual position_structid_pair_type get_pos_sid_pair_2o_helper(CylindricalSurface<traits_type> const& origin_structure1, structure_type_id_type const& target_sid,
                                                                             position_type const& CoM, length_type const& offset, length_type const& rl, rng_type& rng) const
     {                          
-        return this->get_pos_sid_pair_helper_two_origins_any<CylindricalSurface<traits_type> >(origin_structure1, target_sid, CoM, offset, rl, rng);
+        return this->get_pos_sid_pair_2o_helper_any<CylindricalSurface<traits_type> >(origin_structure1, target_sid, CoM, offset, rl, rng);
     }
-    virtual position_structid_pair_type get_pos_sid_pair_helper_two_origins(DiskSurface<traits_type> const& origin_structure1, structure_type_id_type const& target_sid,
+    virtual position_structid_pair_type get_pos_sid_pair_2o_helper(DiskSurface<traits_type> const& origin_structure1, structure_type_id_type const& target_sid,
                                                                             position_type const& CoM, length_type const& offset, length_type const& rl, rng_type& rng) const
     {                          
-        return this->get_pos_sid_pair_helper_two_origins_any<DiskSurface<traits_type> >(origin_structure1, target_sid, CoM, offset, rl, rng);
+        return this->get_pos_sid_pair_2o_helper_any<DiskSurface<traits_type> >(origin_structure1, target_sid, CoM, offset, rl, rng);
     }
-    virtual position_structid_pair_type get_pos_sid_pair_helper_two_origins(PlanarSurface<traits_type> const& origin_structure1, structure_type_id_type const& target_sid,
+    virtual position_structid_pair_type get_pos_sid_pair_2o_helper(PlanarSurface<traits_type> const& origin_structure1, structure_type_id_type const& target_sid,
                                                                             position_type const& CoM, length_type const& offset, length_type const& rl, rng_type& rng) const
     {                          
-        return this->get_pos_sid_pair_helper_two_origins_any<PlanarSurface<traits_type> >(origin_structure1, target_sid, CoM, offset, rl, rng);
+        return this->get_pos_sid_pair_2o_helper_any<PlanarSurface<traits_type> >(origin_structure1, target_sid, CoM, offset, rl, rng);
     }    
     // The template function that defines the actual final dispatch procedure.
     template<typename Tstruct_>
-    position_structid_pair_type get_pos_sid_pair_helper_two_origins_any(Tstruct_ const& origin_structure1, structure_type_id_type const& target_sid, position_type const& CoM,
+    position_structid_pair_type get_pos_sid_pair_2o_helper_any(Tstruct_ const& origin_structure1, structure_type_id_type const& target_sid, position_type const& CoM,
                                                                         length_type const& offset, length_type const& reaction_length, rng_type& rng) const
     {
         if( this->is_parent_of_or_has_same_sid_as(origin_structure1) && origin_structure1.has_valid_target_sid(target_sid) )

--- a/CylindricalSurface.hpp
+++ b/CylindricalSurface.hpp
@@ -317,14 +317,14 @@ public:
     
     // *** 3 *** - Pair reactions => two origin structures
     // First dispatch
-    // Overloading get_pos_sid_pair with signature (origin_structure2, target_structure_type_id, ...)
-   virtual position_structid_pair_type get_pos_sid_pair(structure_type const& origin_structure2, structure_type_id_type const& target_sid, position_type const& CoM,
-                                                        length_type const& offset, length_type const& reaction_length, rng_type& rng) const
-    {   
-        // this just redirects
-        return this->get_pos_sid_pair_2o(origin_structure2, target_sid, CoM, offset, reaction_length, rng);                            
-    }
-    // The actual implementation of the first dispatch
+//     // Overloading get_pos_sid_pair with signature (origin_structure2, target_structure_type_id, ...)
+//    virtual position_structid_pair_type get_pos_sid_pair(structure_type const& origin_structure2, structure_type_id_type const& target_sid, position_type const& CoM,
+//                                                         length_type const& offset, length_type const& reaction_length, rng_type& rng) const
+//     {   
+//         // this just redirects
+//         return this->get_pos_sid_pair_2o(origin_structure2, target_sid, CoM, offset, reaction_length, rng);                            
+//     }
+//     // The actual implementation of the first dispatch
     virtual position_structid_pair_type get_pos_sid_pair_2o(structure_type const& origin_structure2, structure_type_id_type const& target_sid,
                                                          position_type const& CoM, length_type const& offset, length_type const& reaction_length, rng_type& rng) const
     {

--- a/DiskSurface.hpp
+++ b/DiskSurface.hpp
@@ -330,14 +330,14 @@ public:
     
     // *** 3 *** - Pair reactions => two origin structures
     // First dispatch
-    // Overloading get_pos_sid_pair with signature (origin_structure2, target_structure_type_id, ...)
-   virtual position_structid_pair_type get_pos_sid_pair(structure_type const& origin_structure2, structure_type_id_type const& target_sid, position_type const& CoM,
-                                                        length_type const& offset, length_type const& reaction_length, rng_type& rng) const
-    {   
-        // this just redirects
-        return this->get_pos_sid_pair_2o(origin_structure2, target_sid, CoM, offset, reaction_length, rng);                            
-    }
-    // The actual implementation of the first dispatch
+//     // Overloading get_pos_sid_pair with signature (origin_structure2, target_structure_type_id, ...)
+//    virtual position_structid_pair_type get_pos_sid_pair(structure_type const& origin_structure2, structure_type_id_type const& target_sid, position_type const& CoM,
+//                                                         length_type const& offset, length_type const& reaction_length, rng_type& rng) const
+//     {   
+//         // this just redirects
+//         return this->get_pos_sid_pair_2o(origin_structure2, target_sid, CoM, offset, reaction_length, rng);                            
+//     }
+//     // The actual implementation of the first dispatch
     virtual position_structid_pair_type get_pos_sid_pair_2o(structure_type const& origin_structure2, structure_type_id_type const& target_sid,
                                                          position_type const& CoM, length_type const& offset, length_type const& reaction_length, rng_type& rng) const
     {

--- a/DiskSurface.hpp
+++ b/DiskSurface.hpp
@@ -329,41 +329,49 @@ public:
     };
     
     // *** 3 *** - Pair reactions => two origin structures
+    // First dispatch
     // Overloading get_pos_sid_pair with signature (origin_structure2, target_structure_type_id, ...)
-    virtual position_structid_pair_type get_pos_sid_pair(structure_type const& origin_structure2, structure_type_id_type const& target_sid,
+   virtual position_structid_pair_type get_pos_sid_pair(structure_type const& origin_structure2, structure_type_id_type const& target_sid, position_type const& CoM,
+                                                        length_type const& offset, length_type const& reaction_length, rng_type& rng) const
+    {   
+        // this just redirects
+        return this->get_pos_sid_pair_2o(origin_structure2, target_sid, CoM, offset, reaction_length, rng);                            
+    }
+    // The actual implementation of the first dispatch
+    virtual position_structid_pair_type get_pos_sid_pair_2o(structure_type const& origin_structure2, structure_type_id_type const& target_sid,
                                                          position_type const& CoM, length_type const& offset, length_type const& reaction_length, rng_type& rng) const
     {
-        return origin_structure2.get_pos_sid_pair_helper_two_origins(*this, target_sid, CoM, offset, reaction_length, rng);
+        return origin_structure2.get_pos_sid_pair_2o_helper(*this, target_sid, CoM, offset, reaction_length, rng);
     }
     // Second dispatch
-    virtual position_structid_pair_type get_pos_sid_pair_helper_two_origins(CuboidalRegion<traits_type> const& origin_structure1, structure_type_id_type const& target_sid,
+    virtual position_structid_pair_type get_pos_sid_pair_2o_helper(CuboidalRegion<traits_type> const& origin_structure1, structure_type_id_type const& target_sid,
                                                                             position_type const& CoM, length_type const& offset, length_type const& rl, rng_type& rng) const
     {                          
-        return this->get_pos_sid_pair_helper_two_origins_any<CuboidalRegion<traits_type> >(origin_structure1, target_sid, CoM, offset, rl, rng);
+        return this->get_pos_sid_pair_2o_helper_any<CuboidalRegion<traits_type> >(origin_structure1, target_sid, CoM, offset, rl, rng);
     }
-    virtual position_structid_pair_type get_pos_sid_pair_helper_two_origins(SphericalSurface<traits_type> const& origin_structure1, structure_type_id_type const& target_sid,
+    virtual position_structid_pair_type get_pos_sid_pair_2o_helper(SphericalSurface<traits_type> const& origin_structure1, structure_type_id_type const& target_sid,
                                                                             position_type const& CoM, length_type const& offset, length_type const& rl, rng_type& rng) const
     {                          
-        return this->get_pos_sid_pair_helper_two_origins_any<SphericalSurface<traits_type> >(origin_structure1, target_sid, CoM, offset, rl, rng);
+        return this->get_pos_sid_pair_2o_helper_any<SphericalSurface<traits_type> >(origin_structure1, target_sid, CoM, offset, rl, rng);
     }
-    virtual position_structid_pair_type get_pos_sid_pair_helper_two_origins(CylindricalSurface<traits_type> const& origin_structure1, structure_type_id_type const& target_sid,
+    virtual position_structid_pair_type get_pos_sid_pair_2o_helper(CylindricalSurface<traits_type> const& origin_structure1, structure_type_id_type const& target_sid,
                                                                             position_type const& CoM, length_type const& offset, length_type const& rl, rng_type& rng) const
     {                          
-        return this->get_pos_sid_pair_helper_two_origins_any<CylindricalSurface<traits_type> >(origin_structure1, target_sid, CoM, offset, rl, rng);
+        return this->get_pos_sid_pair_2o_helper_any<CylindricalSurface<traits_type> >(origin_structure1, target_sid, CoM, offset, rl, rng);
     }
-    virtual position_structid_pair_type get_pos_sid_pair_helper_two_origins(DiskSurface<traits_type> const& origin_structure1, structure_type_id_type const& target_sid,
+    virtual position_structid_pair_type get_pos_sid_pair_2o_helper(DiskSurface<traits_type> const& origin_structure1, structure_type_id_type const& target_sid,
                                                                             position_type const& CoM, length_type const& offset, length_type const& rl, rng_type& rng) const
     {                          
-        return this->get_pos_sid_pair_helper_two_origins_any<DiskSurface<traits_type> >(origin_structure1, target_sid, CoM, offset, rl, rng);
+        return this->get_pos_sid_pair_2o_helper_any<DiskSurface<traits_type> >(origin_structure1, target_sid, CoM, offset, rl, rng);
     }
-    virtual position_structid_pair_type get_pos_sid_pair_helper_two_origins(PlanarSurface<traits_type> const& origin_structure1, structure_type_id_type const& target_sid,
+    virtual position_structid_pair_type get_pos_sid_pair_2o_helper(PlanarSurface<traits_type> const& origin_structure1, structure_type_id_type const& target_sid,
                                                                             position_type const& CoM, length_type const& offset, length_type const& rl, rng_type& rng) const
     {                          
-        return this->get_pos_sid_pair_helper_two_origins_any<PlanarSurface<traits_type> >(origin_structure1, target_sid, CoM, offset, rl, rng);
+        return this->get_pos_sid_pair_2o_helper_any<PlanarSurface<traits_type> >(origin_structure1, target_sid, CoM, offset, rl, rng);
     }    
     // The template function that defines the actual final dispatch procedure.
     template<typename Tstruct_>
-    position_structid_pair_type get_pos_sid_pair_helper_two_origins_any(Tstruct_ const& origin_structure1, structure_type_id_type const& target_sid, position_type const& CoM,
+    position_structid_pair_type get_pos_sid_pair_2o_helper_any(Tstruct_ const& origin_structure1, structure_type_id_type const& target_sid, position_type const& CoM,
                                                                         length_type const& offset, length_type const& reaction_length, rng_type& rng) const
     {
         if( this->is_parent_of_or_has_same_sid_as(origin_structure1) && origin_structure1.has_valid_target_sid(target_sid) )

--- a/Makefile.am
+++ b/Makefile.am
@@ -217,7 +217,7 @@ _greens_functions_la_SOURCES=\
 	Logger.cpp\
 	ConsoleAppender.cpp
 
-_gfrd_la_LDFLAGS = -module -export-dynamic -avoid-version $(no_undefined)
+_gfrd_la_LDFLAGS = -module -export-dynamic -avoid-version $(no_undefined) -Wl,--no-undefined
 _gfrd_la_LIBADD = binding/libbinding_utils.la
 _gfrd_la_LIBADD += $(LIBBOOSTPYTHON) $(LIBPYTHON) $(GSL_LIBS)
 

--- a/PlanarSurface.hpp
+++ b/PlanarSurface.hpp
@@ -104,8 +104,18 @@ public:
     {
         Real X( rng.uniform(0.,1.) );
         length_type diss_vec_length( X*rl );
-
-        return multiply( base_type::shape().unit_z(), diss_vec_length );
+        
+        if( base_type::shape().is_one_sided() )
+        {
+            return multiply( base_type::shape().unit_z(), diss_vec_length );
+        }
+        else
+        {
+            int sign( rng.uniform(0,1)<=0.5 ? -1 : +1);
+            diss_vec_length *= (Real)sign;
+            
+            return multiply( base_type::shape().unit_z(), diss_vec_length );
+        }
     }
     
     // Normed direction of dissociation from the structure to parent structure

--- a/PlanarSurface.hpp
+++ b/PlanarSurface.hpp
@@ -314,41 +314,49 @@ public:
     };
     
     // *** 3 *** - Pair reactions => two origin structures
+    // First dispatch
     // Overloading get_pos_sid_pair with signature (origin_structure2, target_structure_type_id, ...)
-    virtual position_structid_pair_type get_pos_sid_pair(structure_type const& origin_structure2, structure_type_id_type const& target_sid,
+   virtual position_structid_pair_type get_pos_sid_pair(structure_type const& origin_structure2, structure_type_id_type const& target_sid, position_type const& CoM,
+                                                        length_type const& offset, length_type const& reaction_length, rng_type& rng) const
+    {   
+        // this just redirects
+        return this->get_pos_sid_pair_2o(origin_structure2, target_sid, CoM, offset, reaction_length, rng);                            
+    }
+    // The actual implementation of the first dispatch
+    virtual position_structid_pair_type get_pos_sid_pair_2o(structure_type const& origin_structure2, structure_type_id_type const& target_sid,
                                                          position_type const& CoM, length_type const& offset, length_type const& reaction_length, rng_type& rng) const
     {
-        return origin_structure2.get_pos_sid_pair_helper_two_origins(*this, target_sid, CoM, offset, reaction_length, rng);
+        return origin_structure2.get_pos_sid_pair_2o_helper(*this, target_sid, CoM, offset, reaction_length, rng);
     }
     // Second dispatch
-    virtual position_structid_pair_type get_pos_sid_pair_helper_two_origins(CuboidalRegion<traits_type> const& origin_structure1, structure_type_id_type const& target_sid,
+    virtual position_structid_pair_type get_pos_sid_pair_2o_helper(CuboidalRegion<traits_type> const& origin_structure1, structure_type_id_type const& target_sid,
                                                                             position_type const& CoM, length_type const& offset, length_type const& rl, rng_type& rng) const
     {                          
-        return this->get_pos_sid_pair_helper_two_origins_any<CuboidalRegion<traits_type> >(origin_structure1, target_sid, CoM, offset, rl, rng);
+        return this->get_pos_sid_pair_2o_helper_any<CuboidalRegion<traits_type> >(origin_structure1, target_sid, CoM, offset, rl, rng);
     }
-    virtual position_structid_pair_type get_pos_sid_pair_helper_two_origins(SphericalSurface<traits_type> const& origin_structure1, structure_type_id_type const& target_sid,
+    virtual position_structid_pair_type get_pos_sid_pair_2o_helper(SphericalSurface<traits_type> const& origin_structure1, structure_type_id_type const& target_sid,
                                                                             position_type const& CoM, length_type const& offset, length_type const& rl, rng_type& rng) const
     {                          
-        return this->get_pos_sid_pair_helper_two_origins_any<SphericalSurface<traits_type> >(origin_structure1, target_sid, CoM, offset, rl, rng);
+        return this->get_pos_sid_pair_2o_helper_any<SphericalSurface<traits_type> >(origin_structure1, target_sid, CoM, offset, rl, rng);
     }
-    virtual position_structid_pair_type get_pos_sid_pair_helper_two_origins(CylindricalSurface<traits_type> const& origin_structure1, structure_type_id_type const& target_sid,
+    virtual position_structid_pair_type get_pos_sid_pair_2o_helper(CylindricalSurface<traits_type> const& origin_structure1, structure_type_id_type const& target_sid,
                                                                             position_type const& CoM, length_type const& offset, length_type const& rl, rng_type& rng) const
     {                          
-        return this->get_pos_sid_pair_helper_two_origins_any<CylindricalSurface<traits_type> >(origin_structure1, target_sid, CoM, offset, rl, rng);
+        return this->get_pos_sid_pair_2o_helper_any<CylindricalSurface<traits_type> >(origin_structure1, target_sid, CoM, offset, rl, rng);
     }
-    virtual position_structid_pair_type get_pos_sid_pair_helper_two_origins(DiskSurface<traits_type> const& origin_structure1, structure_type_id_type const& target_sid,
+    virtual position_structid_pair_type get_pos_sid_pair_2o_helper(DiskSurface<traits_type> const& origin_structure1, structure_type_id_type const& target_sid,
                                                                             position_type const& CoM, length_type const& offset, length_type const& rl, rng_type& rng) const
     {                          
-        return this->get_pos_sid_pair_helper_two_origins_any<DiskSurface<traits_type> >(origin_structure1, target_sid, CoM, offset, rl, rng);
+        return this->get_pos_sid_pair_2o_helper_any<DiskSurface<traits_type> >(origin_structure1, target_sid, CoM, offset, rl, rng);
     }
-    virtual position_structid_pair_type get_pos_sid_pair_helper_two_origins(PlanarSurface<traits_type> const& origin_structure1, structure_type_id_type const& target_sid,
+    virtual position_structid_pair_type get_pos_sid_pair_2o_helper(PlanarSurface<traits_type> const& origin_structure1, structure_type_id_type const& target_sid,
                                                                             position_type const& CoM, length_type const& offset, length_type const& rl, rng_type& rng) const
     {                          
-        return this->get_pos_sid_pair_helper_two_origins_any<PlanarSurface<traits_type> >(origin_structure1, target_sid, CoM, offset, rl, rng);
+        return this->get_pos_sid_pair_2o_helper_any<PlanarSurface<traits_type> >(origin_structure1, target_sid, CoM, offset, rl, rng);
     }    
     // The template function that defines the actual final dispatch procedure.
     template<typename Tstruct_>
-    position_structid_pair_type get_pos_sid_pair_helper_two_origins_any(Tstruct_ const& origin_structure1, structure_type_id_type const& target_sid, position_type const& CoM,
+    position_structid_pair_type get_pos_sid_pair_2o_helper_any(Tstruct_ const& origin_structure1, structure_type_id_type const& target_sid, position_type const& CoM,
                                                                         length_type const& offset, length_type const& reaction_length, rng_type& rng) const
     {
         if( this->is_parent_of_or_has_same_sid_as(origin_structure1) && origin_structure1.has_valid_target_sid(target_sid) )

--- a/PlanarSurface.hpp
+++ b/PlanarSurface.hpp
@@ -315,14 +315,14 @@ public:
     
     // *** 3 *** - Pair reactions => two origin structures
     // First dispatch
-    // Overloading get_pos_sid_pair with signature (origin_structure2, target_structure_type_id, ...)
-   virtual position_structid_pair_type get_pos_sid_pair(structure_type const& origin_structure2, structure_type_id_type const& target_sid, position_type const& CoM,
-                                                        length_type const& offset, length_type const& reaction_length, rng_type& rng) const
-    {   
-        // this just redirects
-        return this->get_pos_sid_pair_2o(origin_structure2, target_sid, CoM, offset, reaction_length, rng);                            
-    }
-    // The actual implementation of the first dispatch
+//     // Overloading get_pos_sid_pair with signature (origin_structure2, target_structure_type_id, ...)
+//    virtual position_structid_pair_type get_pos_sid_pair(structure_type const& origin_structure2, structure_type_id_type const& target_sid, position_type const& CoM,
+//                                                         length_type const& offset, length_type const& reaction_length, rng_type& rng) const
+//     {   
+//         // this just redirects
+//         return this->get_pos_sid_pair_2o(origin_structure2, target_sid, CoM, offset, reaction_length, rng);                            
+//     }
+//     // The actual implementation of the first dispatch
     virtual position_structid_pair_type get_pos_sid_pair_2o(structure_type const& origin_structure2, structure_type_id_type const& target_sid,
                                                          position_type const& CoM, length_type const& offset, length_type const& reaction_length, rng_type& rng) const
     {

--- a/Plane.hpp
+++ b/Plane.hpp
@@ -18,6 +18,7 @@ public:
     typedef T_ value_type;
     typedef Vector3<T_> position_type;
     typedef T_ length_type;
+    typedef bool flag_type;
     typedef enum side_enum_type {TOP=0, BOTTOM=1, LEFT=2, RIGHT=3} side_enum_type;  // The typedef is a little bit C style but doesn't matter for C++
 
 public:
@@ -27,7 +28,8 @@ public:
             create_vector<position_type>(1., 0., 0.),
             create_vector<position_type>(0., 1., 0.),
             create_vector<position_type>(0., 0., 1.))),
-          half_extent_(array_gen<length_type>(0.5, 0.5)) {}
+          half_extent_(array_gen<length_type>(0.5, 0.5)),
+          is_one_sided_(true) {}
 
     template<typename Tarray_>
     Plane(position_type const& position, Tarray_ const& half_extent)
@@ -35,7 +37,8 @@ public:
           units_(array_gen(
             create_vector<position_type>(1., 0., 0.),
             create_vector<position_type>(0., 1., 0.),
-            create_vector<position_type>(0., 0., 1.)))
+            create_vector<position_type>(0., 0., 1.))),
+          is_one_sided_(true)
     {
         std::copy(boost::begin(half_extent), boost::end(half_extent),
                   boost::begin(half_extent_));
@@ -44,7 +47,7 @@ public:
     template<typename Tarray1, typename Tarray2>
     Plane(position_type const& position,
         Tarray1 const& units, Tarray2 const& half_extent)
-        : position_(position)
+        : position_(position), is_one_sided_(true)
     {
         std::copy(boost::begin(units), boost::end(units),
                   boost::begin(units_));
@@ -57,7 +60,8 @@ public:
         position_type const& vx,
         position_type const& vy,
         Tarray_ const& half_extent = array_gen<length_type>(0.5, 0.5))
-        : position_(position), units_(array_gen(vx, vy, cross_product(vx, vy)))
+        : position_(position), units_(array_gen(vx, vy, cross_product(vx, vy))),
+          is_one_sided_(true)
     {
         std::copy(boost::begin(half_extent), boost::end(half_extent),
                   boost::begin(half_extent_));
@@ -67,9 +71,10 @@ public:
         position_type const& vx,
         position_type const& vy,
         length_type const& half_lx,
-        length_type const& half_ly)
+        length_type const& half_ly,
+        flag_type const& is_one_sided)
         : position_(position), units_(array_gen(vx, vy, cross_product(vx, vy))),
-          half_extent_(array_gen<length_type>(half_lx, half_ly)) {}
+          half_extent_(array_gen<length_type>(half_lx, half_ly)), is_one_sided_(is_one_sided) {}
 
     position_type const& position() const
     {
@@ -150,6 +155,16 @@ public:
     {
         return half_extent_;
     }
+    
+    flag_type const& is_one_sided() const
+    {
+        return is_one_sided_;
+    }
+    
+    flag_type& is_one_sided()
+    {
+        return is_one_sided_;
+    }
 
     bool operator==(const Plane& rhs) const
     {
@@ -174,6 +189,7 @@ protected:
     position_type position_;
     boost::array<position_type, 3> units_;
     boost::array<length_type, 2> half_extent_;
+    flag_type is_one_sided_;
 };
 
 template<typename T_>

--- a/SphericalSurface.hpp
+++ b/SphericalSurface.hpp
@@ -205,41 +205,49 @@ public:
     };
     
     // *** 3 *** - Pair reactions => two origin structures
+    // First dispatch
     // Overloading get_pos_sid_pair with signature (origin_structure2, target_structure_type_id, ...)
-    virtual position_structid_pair_type get_pos_sid_pair(structure_type const& origin_structure2, structure_type_id_type const& target_sid,
+   virtual position_structid_pair_type get_pos_sid_pair(structure_type const& origin_structure2, structure_type_id_type const& target_sid, position_type const& CoM,
+                                                        length_type const& offset, length_type const& reaction_length, rng_type& rng) const
+    {   
+        // this just redirects
+        return this->get_pos_sid_pair_2o(origin_structure2, target_sid, CoM, offset, reaction_length, rng);                            
+    }
+    // The actual implementation of the first dispatch
+    virtual position_structid_pair_type get_pos_sid_pair_2o(structure_type const& origin_structure2, structure_type_id_type const& target_sid,
                                                          position_type const& CoM, length_type const& offset, length_type const& reaction_length, rng_type& rng) const
     {
-        return origin_structure2.get_pos_sid_pair_helper_two_origins(*this, target_sid, CoM, offset, reaction_length, rng);
+        return origin_structure2.get_pos_sid_pair_2o_helper(*this, target_sid, CoM, offset, reaction_length, rng);
     }
     // Second dispatch
-    virtual position_structid_pair_type get_pos_sid_pair_helper_two_origins(CuboidalRegion<traits_type> const& origin_structure1, structure_type_id_type const& target_sid,
+    virtual position_structid_pair_type get_pos_sid_pair_2o_helper(CuboidalRegion<traits_type> const& origin_structure1, structure_type_id_type const& target_sid,
                                                                             position_type const& CoM, length_type const& offset, length_type const& rl, rng_type& rng) const
     {                          
-        return this->get_pos_sid_pair_helper_two_origins_any<CuboidalRegion<traits_type> >(origin_structure1, target_sid, CoM, offset, rl, rng);
+        return this->get_pos_sid_pair_2o_helper_any<CuboidalRegion<traits_type> >(origin_structure1, target_sid, CoM, offset, rl, rng);
     }
-    virtual position_structid_pair_type get_pos_sid_pair_helper_two_origins(SphericalSurface<traits_type> const& origin_structure1, structure_type_id_type const& target_sid,
+    virtual position_structid_pair_type get_pos_sid_pair_2o_helper(SphericalSurface<traits_type> const& origin_structure1, structure_type_id_type const& target_sid,
                                                                             position_type const& CoM, length_type const& offset, length_type const& rl, rng_type& rng) const
     {                          
-        return this->get_pos_sid_pair_helper_two_origins_any<SphericalSurface<traits_type> >(origin_structure1, target_sid, CoM, offset, rl, rng);
+        return this->get_pos_sid_pair_2o_helper_any<SphericalSurface<traits_type> >(origin_structure1, target_sid, CoM, offset, rl, rng);
     }
-    virtual position_structid_pair_type get_pos_sid_pair_helper_two_origins(CylindricalSurface<traits_type> const& origin_structure1, structure_type_id_type const& target_sid,
+    virtual position_structid_pair_type get_pos_sid_pair_2o_helper(CylindricalSurface<traits_type> const& origin_structure1, structure_type_id_type const& target_sid,
                                                                             position_type const& CoM, length_type const& offset, length_type const& rl, rng_type& rng) const
     {                          
-        return this->get_pos_sid_pair_helper_two_origins_any<CylindricalSurface<traits_type> >(origin_structure1, target_sid, CoM, offset, rl, rng);
+        return this->get_pos_sid_pair_2o_helper_any<CylindricalSurface<traits_type> >(origin_structure1, target_sid, CoM, offset, rl, rng);
     }
-    virtual position_structid_pair_type get_pos_sid_pair_helper_two_origins(DiskSurface<traits_type> const& origin_structure1, structure_type_id_type const& target_sid,
+    virtual position_structid_pair_type get_pos_sid_pair_2o_helper(DiskSurface<traits_type> const& origin_structure1, structure_type_id_type const& target_sid,
                                                                             position_type const& CoM, length_type const& offset, length_type const& rl, rng_type& rng) const
     {                          
-        return this->get_pos_sid_pair_helper_two_origins_any<DiskSurface<traits_type> >(origin_structure1, target_sid, CoM, offset, rl, rng);
+        return this->get_pos_sid_pair_2o_helper_any<DiskSurface<traits_type> >(origin_structure1, target_sid, CoM, offset, rl, rng);
     }
-    virtual position_structid_pair_type get_pos_sid_pair_helper_two_origins(PlanarSurface<traits_type> const& origin_structure1, structure_type_id_type const& target_sid,
+    virtual position_structid_pair_type get_pos_sid_pair_2o_helper(PlanarSurface<traits_type> const& origin_structure1, structure_type_id_type const& target_sid,
                                                                             position_type const& CoM, length_type const& offset, length_type const& rl, rng_type& rng) const
     {                          
-        return this->get_pos_sid_pair_helper_two_origins_any<PlanarSurface<traits_type> >(origin_structure1, target_sid, CoM, offset, rl, rng);
+        return this->get_pos_sid_pair_2o_helper_any<PlanarSurface<traits_type> >(origin_structure1, target_sid, CoM, offset, rl, rng);
     }    
     // The template function that defines the actual final dispatch procedure.
     template<typename Tstruct_>
-    position_structid_pair_type get_pos_sid_pair_helper_two_origins_any(Tstruct_ const& origin_structure1, structure_type_id_type const& target_sid, position_type const& CoM,
+    position_structid_pair_type get_pos_sid_pair_2o_helper_any(Tstruct_ const& origin_structure1, structure_type_id_type const& target_sid, position_type const& CoM,
                                                                         length_type const& offset, length_type const& reaction_length, rng_type& rng) const
     {
         if( this->is_parent_of_or_has_same_sid_as(origin_structure1) && origin_structure1.has_valid_target_sid(target_sid) )

--- a/SphericalSurface.hpp
+++ b/SphericalSurface.hpp
@@ -206,14 +206,14 @@ public:
     
     // *** 3 *** - Pair reactions => two origin structures
     // First dispatch
-    // Overloading get_pos_sid_pair with signature (origin_structure2, target_structure_type_id, ...)
-   virtual position_structid_pair_type get_pos_sid_pair(structure_type const& origin_structure2, structure_type_id_type const& target_sid, position_type const& CoM,
-                                                        length_type const& offset, length_type const& reaction_length, rng_type& rng) const
-    {   
-        // this just redirects
-        return this->get_pos_sid_pair_2o(origin_structure2, target_sid, CoM, offset, reaction_length, rng);                            
-    }
-    // The actual implementation of the first dispatch
+//     // Overloading get_pos_sid_pair with signature (origin_structure2, target_structure_type_id, ...)
+//    virtual position_structid_pair_type get_pos_sid_pair(structure_type const& origin_structure2, structure_type_id_type const& target_sid, position_type const& CoM,
+//                                                         length_type const& offset, length_type const& reaction_length, rng_type& rng) const
+//     {   
+//         // this just redirects
+//         return this->get_pos_sid_pair_2o(origin_structure2, target_sid, CoM, offset, reaction_length, rng);                            
+//     }
+//     // The actual implementation of the first dispatch
     virtual position_structid_pair_type get_pos_sid_pair_2o(structure_type const& origin_structure2, structure_type_id_type const& target_sid,
                                                          position_type const& CoM, length_type const& offset, length_type const& reaction_length, rng_type& rng) const
     {

--- a/Structure.hpp
+++ b/Structure.hpp
@@ -208,9 +208,9 @@ public:
     // This is called as a method of origin_structure1 with origin_structure2 as an argument.
     virtual position_structid_pair_type get_pos_sid_pair_2o(structure_type const& origin_structure2, structure_type_id_type const& target_sid, position_type const& CoM,
                                                             length_type const& offset, length_type const& reaction_length, rng_type& rng) const = 0;
-    // Some convenient method overloading; this is just a redirect to the above                                       
-    virtual position_structid_pair_type get_pos_sid_pair(structure_type const& origin_structure2, structure_type_id_type const& target_sid, position_type const& CoM,
-                                                         length_type const& offset, length_type const& reaction_length, rng_type& rng) const = 0;
+//     // Some convenient method overloading; this is just a redirect to the above                                       
+//     virtual position_structid_pair_type get_pos_sid_pair(structure_type const& origin_structure2, structure_type_id_type const& target_sid, position_type const& CoM,
+//                                                          length_type const& offset, length_type const& reaction_length, rng_type& rng) const = 0;
     // Second dispatch
     // The helper functions are the dispatch acceptors and have to be declared for each derived structure class because C++ does not support virtual templates.
     virtual position_structid_pair_type get_pos_sid_pair_2o_helper(CuboidalRegion<traits_type> const& origin_structure1, structure_type_id_type const& target_sid, position_type const& CoM,

--- a/Structure.hpp
+++ b/Structure.hpp
@@ -164,7 +164,7 @@ public:
     virtual position_structid_pair_type get_pos_sid_pair(structure_type const& target_structure, position_type const& position,
                                                          length_type const& offset, length_type const& rl, rng_type& rng) const = 0;
     // Second dispatch
-    // This helper function has to be declared for each derived structure class because C++ does not support virtual templates (yet).
+    // The helper functions are the dispatch acceptors and have to be declared for each derived structure class because C++ does not support virtual templates.
     virtual position_structid_pair_type get_pos_sid_pair_helper(CuboidalRegion<traits_type> const& origin_structure, position_type const& position,
                                                         length_type const& offset, length_type const& rl, rng_type& rng) const = 0;
     virtual position_structid_pair_type get_pos_sid_pair_helper(SphericalSurface<traits_type> const& origin_structure, position_type const& position,
@@ -180,7 +180,7 @@ public:
     virtual position_structid_pair_pair_type get_pos_sid_pair_pair(structure_type const& target_structure, position_type const& position,
                                                                    species_type const& s_orig, species_type const& s_targ, length_type const& rl, rng_type& rng) const = 0;
     // Second dispatch
-    // This helper function has to be declared for each derived structure class because C++ does not support virtual templates (yet).
+    // The helper functions are dispatch acceptors and have to be declared for each derived structure class because C++ does not support virtual templates.
     virtual position_structid_pair_pair_type get_pos_sid_pair_pair_helper(CuboidalRegion<traits_type> const& origin_structure, position_type const& position,
                                                                           species_type const& s_orig, species_type const& s_targ, length_type const& rl, rng_type& rng) const = 0;
     virtual position_structid_pair_pair_type get_pos_sid_pair_pair_helper(SphericalSurface<traits_type> const& origin_structure, position_type const& position,
@@ -204,23 +204,25 @@ public:
     //   - in case of equal structure type id's it can end up on either origin structure
     //     and apply_boundary will handle the right placement afterwards.
        
-    // First dispatch, overloading method call structure.get_pos_sid_pair
+    // First dispatch
     // This is called as a method of origin_structure1 with origin_structure2 as an argument.
+    virtual position_structid_pair_type get_pos_sid_pair_2o(structure_type const& origin_structure2, structure_type_id_type const& target_sid, position_type const& CoM,
+                                                            length_type const& offset, length_type const& reaction_length, rng_type& rng) const = 0;
+    // Some convenient method overloading; this is just a redirect to the above                                       
     virtual position_structid_pair_type get_pos_sid_pair(structure_type const& origin_structure2, structure_type_id_type const& target_sid, position_type const& CoM,
-                                                         length_type const& offset, length_type const& reaction_length, rng_type& rng) const = 0;    
+                                                         length_type const& offset, length_type const& reaction_length, rng_type& rng) const = 0;
     // Second dispatch
-    // This helper function has to be declared for each derived structure class because C++ does not support virtual templates (yet).
-    // It is called as a method of origin_structure2 by origin_structure1 with origin_structure1 as an argument
-    virtual position_structid_pair_type get_pos_sid_pair_helper_two_origins(CuboidalRegion<traits_type> const& origin_structure1, structure_type_id_type const& target_sid, position_type const& CoM,
-                                                                            length_type const& offset, length_type const& reaction_length, rng_type& rng) const = 0;
-    virtual position_structid_pair_type get_pos_sid_pair_helper_two_origins(SphericalSurface<traits_type> const& origin_structure1, structure_type_id_type const& target_sid, position_type const& CoM,
-                                                                            length_type const& offset, length_type const& reaction_length, rng_type& rng) const = 0;
-    virtual position_structid_pair_type get_pos_sid_pair_helper_two_origins(CylindricalSurface<traits_type> const& origin_structure1, structure_type_id_type const& target_sid, position_type const& CoM,
-                                                                            length_type const& offset, length_type const& reaction_length, rng_type& rng) const = 0;
-    virtual position_structid_pair_type get_pos_sid_pair_helper_two_origins(DiskSurface<traits_type> const& origin_structure1, structure_type_id_type const& target_sid, position_type const& CoM,
-                                                                            length_type const& offset, length_type const& reaction_length, rng_type& rng) const = 0;
-    virtual position_structid_pair_type get_pos_sid_pair_helper_two_origins(PlanarSurface<traits_type> const& origin_structure1, structure_type_id_type const& target_sid, position_type const& CoM,
-                                                                            length_type const& offset, length_type const& reaction_length, rng_type& rng) const = 0;
+    // The helper functions are the dispatch acceptors and have to be declared for each derived structure class because C++ does not support virtual templates.
+    virtual position_structid_pair_type get_pos_sid_pair_2o_helper(CuboidalRegion<traits_type> const& origin_structure1, structure_type_id_type const& target_sid, position_type const& CoM,
+                                                                   length_type const& offset, length_type const& reaction_length, rng_type& rng) const = 0;
+    virtual position_structid_pair_type get_pos_sid_pair_2o_helper(SphericalSurface<traits_type> const& origin_structure1, structure_type_id_type const& target_sid, position_type const& CoM,
+                                                                   length_type const& offset, length_type const& reaction_length, rng_type& rng) const = 0;
+    virtual position_structid_pair_type get_pos_sid_pair_2o_helper(CylindricalSurface<traits_type> const& origin_structure1, structure_type_id_type const& target_sid, position_type const& CoM,
+                                                                   length_type const& offset, length_type const& reaction_length, rng_type& rng) const = 0;
+    virtual position_structid_pair_type get_pos_sid_pair_2o_helper(DiskSurface<traits_type> const& origin_structure1, structure_type_id_type const& target_sid, position_type const& CoM,
+                                                                   length_type const& offset, length_type const& reaction_length, rng_type& rng) const = 0;
+    virtual position_structid_pair_type get_pos_sid_pair_2o_helper(PlanarSurface<traits_type> const& origin_structure1, structure_type_id_type const& target_sid, position_type const& CoM,
+                                                                   length_type const& offset, length_type const& reaction_length, rng_type& rng) const = 0;
     
     // Some further helper functions used by template<typename Tstruct_> get_pos_sid_pair_helper_two_origins_any(...),
     // which is the final dispatch template defined in each of the derived classes and makes use of the two following checker functions:

--- a/StructureUtils.hpp
+++ b/StructureUtils.hpp
@@ -36,6 +36,8 @@ struct StructureUtils
     typedef typename simulator_type::planar_surface_type        planar_surface_type;
     typedef typename simulator_type::cuboidal_region_type       cuboidal_region_type;
     typedef typename simulator_type::world_type::traits_type::rng_type rng_type;
+    
+    typedef bool flag_type;
  
     static planar_surface_type* create_planar_surface(
             structure_type_id_type const& sid,          // This refers to the structure type of the planar surface
@@ -44,7 +46,7 @@ struct StructureUtils
             position_type const& unit_x,
             position_type const& unit_y,
             length_type const& lx,
-            length_type const& ly,
+            length_type const& ly,            
             structure_id_type const& parent_struct_id)
     {
         BOOST_ASSERT(is_cartesian_versor(unit_x));
@@ -59,10 +61,40 @@ struct StructureUtils
 
         const position_type pos(add(add(corner, multiply(unit_x, half_lx)),
                                                 multiply(unit_y, half_ly)));
+        const flag_type is_one_sided(true);
 
         return new planar_surface_type(name, sid, parent_struct_id,
                                        plane_type(pos, unit_x, unit_y,
-                                                  half_lx, half_ly));
+                                                  half_lx, half_ly, is_one_sided));
+    }
+    
+    static planar_surface_type* create_double_sided_planar_surface(
+            structure_type_id_type const& sid,          // This refers to the structure type of the planar surface
+            structure_name_type   const& name,
+            position_type const& corner,
+            position_type const& unit_x,
+            position_type const& unit_y,
+            length_type const& lx,
+            length_type const& ly,            
+            structure_id_type const& parent_struct_id)
+    {
+        BOOST_ASSERT(is_cartesian_versor(unit_x));
+        BOOST_ASSERT(is_cartesian_versor(unit_y));
+        BOOST_ASSERT(is_cartesian_versor(cross_product(unit_x, unit_y)));
+
+        // Note that when calling the function the origin is in the corner and the length
+        // is the whole length of the plane, whereas for 'plane_type' the origin is in the
+        // center of the plane (pos) and that the length is only half lengths 'half_lx' and 'half_ly'.
+        const length_type half_lx(lx / 2);
+        const length_type half_ly(ly / 2);
+
+        const position_type pos(add(add(corner, multiply(unit_x, half_lx)),
+                                                multiply(unit_y, half_ly)));
+        const flag_type is_one_sided(false);
+
+        return new planar_surface_type(name, sid, parent_struct_id,
+                                       plane_type(pos, unit_x, unit_y,
+                                                  half_lx, half_ly, is_one_sided));
     }
 
     static spherical_surface_type* create_spherical_surface(

--- a/binding/Plane.hpp
+++ b/binding/Plane.hpp
@@ -29,7 +29,8 @@ inline boost::python::objects::class_base register_plane_class(char const* name)
                   typename impl_type::position_type, 
                   typename impl_type::position_type, 
                   typename impl_type::length_type,
-                  typename impl_type::length_type>())
+                  typename impl_type::length_type,
+                  bool>())
         .def(init<typename impl_type::position_type, 
                   boost::array<typename impl_type::length_type, 2> >())
         .add_property("position",
@@ -102,6 +103,20 @@ inline boost::python::objects::class_base register_plane_class(char const* name)
                     typename impl_type::position_type,
                     &impl_type::unit_z,
                     &impl_type::unit_z>::set))
+        .add_property("is_one_sided",
+            make_function(
+                &peer::util::reference_accessor_wrapper<
+                    impl_type,
+                    typename impl_type::flag_type,
+                    &impl_type::is_one_sided,
+                    &impl_type::is_one_sided>::get,
+                return_value_policy<return_by_value>()),
+            make_function(
+                &peer::util::reference_accessor_wrapper<
+                    impl_type,
+                    typename impl_type::flag_type,
+                    &impl_type::is_one_sided,
+                    &impl_type::is_one_sided>::set))
         ;
                         
 }

--- a/binding/Structure.hpp
+++ b/binding/Structure.hpp
@@ -49,6 +49,9 @@ inline boost::python::objects::class_base register_structure_class(char const *n
         .def("project_point", &impl_type::project_point)
         .def("deflect", &impl_type::deflect)
 //        .def("deflect_back", &impl_type::deflect_back)
+        .def("get_pos_sid_pair", &impl_type::get_pos_sid_pair)
+        .def("get_pos_sid_pair_pair", &impl_type::get_pos_sid_pair_pair)
+        .def("get_pos_sid_pair_2o", &impl_type::get_pos_sid_pair_2o)
         ;
 }
 

--- a/binding/module_functions.cpp
+++ b/binding/module_functions.cpp
@@ -47,6 +47,8 @@ void register_module_functions()
     def( "cyclic_transpose", &cyclic_transpose<Position, element_type_of<Position>::type> );
     def("create_planar_surface", &StructureUtils::create_planar_surface,
             return_value_policy<manage_new_object>());
+    def("create_double_sided_planar_surface", &StructureUtils::create_double_sided_planar_surface,
+            return_value_policy<manage_new_object>());
     def("create_spherical_surface", &StructureUtils::create_spherical_surface,
             return_value_policy<manage_new_object>());
     def("create_cylindrical_surface", &StructureUtils::create_cylindrical_surface,

--- a/egfrd.py
+++ b/egfrd.py
@@ -962,8 +962,13 @@ class EGFRDSimulator(ParticleSimulatorBase):
                 # TODO make these generators for efficiency
                 product_pos_list = []
                 if isinstance(reactant_structure, PlanarSurface):
-                    a = myrandom.choice(-1, 1)
-                    directions = [-a,a]
+                    if not reactant_structure.shape.is_one_sided:
+                        # randomize unbinding direction
+                        a = myrandom.choice(-1, 1)
+                        directions = [-a,a]
+                    else:
+                        # unbinding always in direction of unit_z
+                        directions = [1]
                     # place the center of mass of the particle 'at contact' with the membrane
                     vector_length = (product_radius + 0.0) * (MINIMAL_SEPARATION_FACTOR - 1.0)  # the thickness of the membrane is 0.0
                     product_pos_list = [reactant_pos + vector_length * reactant_structure.shape.unit_z * direction \

--- a/egfrd.py
+++ b/egfrd.py
@@ -223,7 +223,7 @@ class EGFRDSimulator(ParticleSimulatorBase):
 
         self.DEFAULT_DT_FACTOR = 1e-5           # Diffusion time prefactor in oldBD algortithm to determine time step.
         
-        self.DEFAULT_STEP_SIZE_FACTOR = 0.05    # The maximum step size in the newBD algorithm is determined as DSSF * sigma_min.
+        self.DEFAULT_STEP_SIZE_FACTOR = 0.05    # The maximum step size in the newBD algorithm is determined as DSSF * sigma_min.  # TESTING was 0.05
                                                 # Make sure that DEFAULT_STEP_SIZE_FACTOR < MULTI_SHELL_FACTOR, or else the 
                                                 # reaction volume sticks out of the multi. 
 
@@ -979,9 +979,18 @@ class EGFRDSimulator(ParticleSimulatorBase):
                         product_pos_list.append(vector)
 
                 elif isinstance(reactant_structure, DiskSurface):
-                    vector_length = 1.0*product_radius * MINIMAL_SEPARATION_FACTOR
-                    vector        = reactant_pos + vector_length * reactant_structure.shape.unit_z
-                    product_pos_list.append(vector)
+                    # unbinding in direction of disk unit vector
+                    #vector_length = 1.0*product_radius * MINIMAL_SEPARATION_FACTOR
+                    #vector        = reactant_pos + vector_length * reactant_structure.shape.unit_z
+                    #product_pos_list.append(vector)
+                    # unbinding perpendicularly to disk unit vector (i.e. like on cylinder)
+                    vector_length = (product_radius + reactant_structure.shape.radius) * MINIMAL_SEPARATION_FACTOR
+                    for _ in range(self.dissociation_retry_moves):
+                        unit_vector3D = random_unit_vector()
+                        unit_vector2D = normalize(unit_vector3D - 
+                                        (reactant_structure.shape.unit_z * numpy.dot(unit_vector3D, reactant_structure.shape.unit_z)))
+                        vector = reactant_pos + vector_length * unit_vector2D
+                        product_pos_list.append(vector)
 
                 else:
                     # cannot decay from 3D to other structure

--- a/egfrd.py
+++ b/egfrd.py
@@ -962,13 +962,13 @@ class EGFRDSimulator(ParticleSimulatorBase):
                 # TODO make these generators for efficiency
                 product_pos_list = []
                 if isinstance(reactant_structure, PlanarSurface):
-                    if not reactant_structure.shape.is_one_sided:
+                    if reactant_structure.shape.is_one_sided:
+                        # unbinding always in direction of unit_z
+                        directions = [1]
+                    else:
                         # randomize unbinding direction
                         a = myrandom.choice(-1, 1)
                         directions = [-a,a]
-                    else:
-                        # unbinding always in direction of unit_z
-                        directions = [1]
                     # place the center of mass of the particle 'at contact' with the membrane
                     vector_length = (product_radius + 0.0) * (MINIMAL_SEPARATION_FACTOR - 1.0)  # the thickness of the membrane is 0.0
                     product_pos_list = [reactant_pos + vector_length * reactant_structure.shape.unit_z * direction \
@@ -1098,7 +1098,7 @@ class EGFRDSimulator(ParticleSimulatorBase):
 
                 if isinstance(reactant_structure, PlanarSurface):
                     # draw a number of new positions for the two product particles
-                    # TODO make this into a generator
+                    # TODO make this a generator
 
                     product_pos_list = []
                     for _ in range(self.dissociation_retry_moves):
@@ -1111,7 +1111,12 @@ class EGFRDSimulator(ParticleSimulatorBase):
                         iv *= MINIMAL_SEPARATION_FACTOR
 
                         # determine the side of the membrane the dissociation takes place
-                        unit_z = reactant_structure.shape.unit_z * myrandom.choice(-1, 1)
+                        if(reactant_structure.shape.is_one_sided):
+                            unit_z = reactant_structure.shape.unit_z
+                        else:
+                            unit_z = reactant_structure.shape.unit_z * myrandom.choice(-1, 1)
+
+                        # calculate the new positions and structure IDs
                         newposA, newposB, sidA, sidB = MixedPair2D3D.do_back_transform(reactant_pos, iv, DA, DB,
                                                                                        productA_radius, productB_radius,
                                                                                        reactant_structure, reactant_structure,

--- a/gfrdbase.py
+++ b/gfrdbase.py
@@ -186,7 +186,7 @@ def create_world(m, matrix_size=10):
     world.model = m
     return world
 
-def create_box(world, structure_type, center, size):
+def create_box(world, structure_type, center, size, one_sided=True):
     """ Creates a box of PlanarSurface sections and adds it to the world.
 
         Arguments:
@@ -212,13 +212,18 @@ def create_box(world, structure_type, center, size):
     name = 'box'
     def_struct_id = world.get_def_structure_id()
     
+    if one_sided:
+        create_planar_surface = model.create_planar_surface
+    else:
+        create_planar_surface = model.create_double_sided_planar_surface
+
     # Create the planes and add them to the world
-    front  = model.create_planar_surface(sid, name+'_front', [center[0] - size[0]/2, center[1] - size[1]/2, center[2] - size[2]/2], [0, 0, 1], [1, 0, 0], size[2], size[0], def_struct_id)
-    back   = model.create_planar_surface(sid, name+'_back',  [center[0] - size[0]/2, center[1] + size[1]/2, center[2] - size[2]/2], [1, 0, 0], [0, 0, 1], size[0], size[2], def_struct_id)
-    right  = model.create_planar_surface(sid, name+'_right', [center[0] + size[0]/2, center[1] - size[1]/2, center[2] - size[2]/2], [0, 0, 1], [0, 1, 0], size[2], size[1], def_struct_id)
-    left   = model.create_planar_surface(sid, name+'_left',  [center[0] - size[0]/2, center[1] - size[1]/2, center[2] - size[2]/2], [0, 1, 0], [0, 0, 1], size[1], size[2], def_struct_id)
-    top    = model.create_planar_surface(sid, name+'_top',   [center[0] - size[0]/2, center[1] - size[1]/2, center[2] + size[2]/2], [0, 1, 0], [1, 0, 0], size[1], size[0], def_struct_id)
-    bottom = model.create_planar_surface(sid, name+'_bottom',[center[0] - size[0]/2, center[1] - size[1]/2, center[2] - size[2]/2], [1, 0, 0], [0, 1, 0], size[0], size[1], def_struct_id)
+    front  = create_planar_surface(sid, name+'_front', [center[0] - size[0]/2, center[1] - size[1]/2, center[2] - size[2]/2], [0, 0, 1], [1, 0, 0], size[2], size[0], def_struct_id)
+    back   = create_planar_surface(sid, name+'_back',  [center[0] - size[0]/2, center[1] + size[1]/2, center[2] - size[2]/2], [1, 0, 0], [0, 0, 1], size[0], size[2], def_struct_id)
+    right  = create_planar_surface(sid, name+'_right', [center[0] + size[0]/2, center[1] - size[1]/2, center[2] - size[2]/2], [0, 0, 1], [0, 1, 0], size[2], size[1], def_struct_id)
+    left   = create_planar_surface(sid, name+'_left',  [center[0] - size[0]/2, center[1] - size[1]/2, center[2] - size[2]/2], [0, 1, 0], [0, 0, 1], size[1], size[2], def_struct_id)
+    top    = create_planar_surface(sid, name+'_top',   [center[0] - size[0]/2, center[1] - size[1]/2, center[2] + size[2]/2], [0, 1, 0], [1, 0, 0], size[1], size[0], def_struct_id)
+    bottom = create_planar_surface(sid, name+'_bottom',[center[0] - size[0]/2, center[1] - size[1]/2, center[2] - size[2]/2], [1, 0, 0], [0, 1, 0], size[0], size[1], def_struct_id)
     world.add_structure(front)
     world.add_structure(back)
     world.add_structure(right)

--- a/model.py
+++ b/model.py
@@ -1,6 +1,6 @@
 import _gfrd
 from _gfrd import create_cuboidal_region, create_cylindrical_surface, \
-        create_disk_surface, create_planar_surface
+        create_disk_surface, create_planar_surface, create_double_sided_planar_surface
 import numpy
 
 __all__ = [
@@ -20,6 +20,7 @@ __all__ = [
     'create_cylindrical_surface',
     'create_disk_surface',
     'create_planar_surface',
+    'create_double_sided_planar_surface',
     ]
 
 
@@ -100,7 +101,44 @@ Surfaces are not allowed to touch or overlap.
 _gfrd.create_planar_surface.__doc__ = \
 """create_planar_surface(sid, id, corner, unit_x, unit_y, length_x, length_y)
 
-Create and return a new planar Surface.
+Create and return a new planar surface with one-sided particle unbinding,
+i.e. particles on this surface will unbind in the direction of the normal
+vector unit_z (cross product of unit_x and unit_y).
+
+Arguments:
+    - sid
+        the structure type of the planar surface.
+    - id
+        the name of the structure
+    - corner
+        the point [x, y, z] on the plane closest to [0, 0, 0]. Units: 
+        [meters, meters, meters]
+    - unit_x
+        a unit vector [1, 0, 0], [0, 1, 0] or [0, 0, 1] along the 
+        plane.
+    - unit_y
+        a unit vector [1, 0, 0], [0, 1, 0] or [0, 0, 1] along the plane 
+        and perpendicular to unit_x.
+    - length_x
+        the length of the plane along the unit vector unit_x. Should be 
+        equal to the world_size. Units: meters.
+    - length_y
+        the length of the plane along the unit vector unit_y. Should be 
+        equal to the world_size. Units: meters.
+
+Surfaces are not allowed to overlap.
+
+Todo: allow the user to specify the position of a planar surface 
+relative to a region.
+
+"""
+
+_gfrd.create_double_sided_planar_surface.__doc__ = \
+"""create_double_sided_planar_surface(sid, id, corner, unit_x, unit_y, length_x, length_y)
+
+Create and return a new planar surface with double-sided particle unbinding,
+i.e. particles on this surface will unbind randomly in either unit_z or -unit_z
+direction (unit_z = cross product of unit_x and unit_y).
 
 Arguments:
     - sid

--- a/newBDPropagator.hpp
+++ b/newBDPropagator.hpp
@@ -564,7 +564,7 @@ private:
                             
                             // Produce two new positions and structure IDs
                             // Note that reactant_structure = prod0_structure here.
-                            LOG_DEBUG(("Attempting single reaction: calling get_pos_sid_pair with %s", boost::lexical_cast<std::string>(prod1_structure).c_str())); // TESTING
+                            LOG_DEBUG(("Attempting single reaction: calling get_pos_sid_pair_pair with %s", boost::lexical_cast<std::string>(prod1_structure).c_str())); // TESTING
                             pos0pos1_pair = reactant_structure->get_pos_sid_pair_pair(*prod1_structure, reactant_pos, product0_species, product1_species, reaction_length_, rng_ );
                             // Remember the new structure IDs
                             prod0_struct_id = pos0pos1_pair.first.second;
@@ -750,8 +750,8 @@ private:
                         // origin_structure types.
                         const length_type offset(0.0);
                         LOG_DEBUG(("Attempting pair reaction: calling get_pos_sid_pair with %s", boost::lexical_cast<std::string>(reactant1_structure).c_str())); // TESTING
-                        const position_structid_pair_type product_pos_struct_id( reactant0_structure->get_pos_sid_pair(*reactant1_structure, product_structure_type_id,
-                                                                                                                       reactants_CoM, offset, reaction_length_, rng_ ) );
+                        const position_structid_pair_type product_pos_struct_id( reactant0_structure->get_pos_sid_pair_2o(*reactant1_structure, product_structure_type_id,
+                                                                                                                          reactants_CoM, offset, reaction_length_, rng_ ) );
                         // Apply the boundary conditions; this is particularly important here because the CoM projection as produced by the function above
                         // in some cases might end up out of the target_structure (e.g. in case the two reactants are coming from adjacent planes
                         tx_.apply_boundary(product_pos_struct_id);

--- a/newBDPropagator.hpp
+++ b/newBDPropagator.hpp
@@ -288,6 +288,9 @@ public:
         //// 6.1 REACTIONS WITH OTHER PARTICLES
         /* Now attempt a reaction with all particles inside the reaction volume. */
         j = 0;
+        accumulated_prob = 0.0; // has to be reset to zero otherwise the particle will react even
+                                // if the reaction rate is zero!
+                                // TODO Is that correct or should everything be in one loop???
         while(j < particles_in_overlap)
         {
             const particle_id_pair_and_distance & overlap_particle( overlap_particles->at(j) );

--- a/newBDPropagator.hpp
+++ b/newBDPropagator.hpp
@@ -289,7 +289,6 @@ public:
                         ++rejected_move_count_;
                         log_.info("treating reaction as forbidden and resetting acc. probability by %s", prob_increase);
                         accumulated_prob -= prob_increase;
-                        // TODO return true here?
                     }
                 }
                 else
@@ -313,7 +312,7 @@ public:
             species_type s0(pp_species);
             species_type s1(tx_.get_species(overlap_particle.first.second.sid()));
 
-            // TODO Remove this if everything works fine!
+            // TODO Remove this when everything works fine!
 /*            // If the structure_types of the reactants are not equal, one of the reactants has to come from the bulk,
             // and we let this be s1, the particle from the surface is named s0.
             if(s0.structure_type_id() != s1.structure_type_id())

--- a/shells.py
+++ b/shells.py
@@ -188,7 +188,11 @@ class testInteractionSingle(testSingle, Others):
         self.particle_surface_distance = self.world.distance(self.target_structure.shape, self.pid_particle_pair[1].position)
 
         # The reference_vector is the normalized vector from the reference_point to the particle
-        self.reference_vector = normalize(pos_transposed - self.reference_point)
+        if pos_transposed != self.reference_point :
+            self.reference_vector = normalize(pos_transposed - self.reference_point)
+        else:
+            self.reference_vector = 0
+            raise testShellError('(testInteractionSingle). reference vector = 0.')
 
 class testTransitionSingle(testSingle, Others):
 

--- a/shells.py
+++ b/shells.py
@@ -980,7 +980,7 @@ def get_dr_dzright_dzleft_to_CylindricalShape(shape, testShell, r, z_right, z_le
                 r1_min = math.sqrt((scale_center_to_shell_x-shell_half_length)**2 + (scale_center_to_shell_y-shell_radius)**2)*(1.0+TOLERANCE)
                 h1_min = r1_min/math.tan(scale_angle)
 
-#        print "situation= ", situation
+        print "situation= ", situation
         #################
         if situation == 1:
             # shell hits the scaling cylinder with its flat surface on the radial side
@@ -992,8 +992,9 @@ def get_dr_dzright_dzleft_to_CylindricalShape(shape, testShell, r, z_right, z_le
             # TODO we have a solution but it can only be found with a root finder -> slow
             tan_scale_angle = math.tan(scale_angle)
 
-            if scale_angle <= Pi/4.0:
+            if scale_angle < Pi/4.0:
                 def h1(x):
+                    print "value = %s" % str((x*tan_scale_angle)**2 - (scale_center_to_shell_x - shell_half_length)) # TODO DEBUG output, remove when done
                     return x - scale_center_to_shell_z + \
                            math.sqrt(shell_radius**2 - (scale_center_to_shell_y - math.sqrt((x*tan_scale_angle)**2 - (scale_center_to_shell_x - shell_half_length)**2) )**2 )
 

--- a/shells.py
+++ b/shells.py
@@ -809,6 +809,7 @@ def get_dr_dzright_dzleft_to_CylindricalShape(shape, testShell, r, z_right, z_le
         z2 = z_right
 
     relative_orientation = abs(numpy.dot(orientation_vector, shape.unit_z))
+
     if feq(relative_orientation, 1.0):
     ### If the cylinders are oriented parallelly
 
@@ -980,7 +981,7 @@ def get_dr_dzright_dzleft_to_CylindricalShape(shape, testShell, r, z_right, z_le
                 r1_min = math.sqrt((scale_center_to_shell_x-shell_half_length)**2 + (scale_center_to_shell_y-shell_radius)**2)*(1.0+TOLERANCE)
                 h1_min = r1_min/math.tan(scale_angle)
 
-        print "situation= ", situation
+        #print "situation= ", situation
         #################
         if situation == 1:
             # shell hits the scaling cylinder with its flat surface on the radial side
@@ -1950,11 +1951,9 @@ class CylindricalSurfaceCapInteractiontestShell(CylindricaltestShell, testIntera
                                  (str(e)))
 
     def get_orientation_vector(self):
-        # The orientation vector is collinear with the parent cylinder axis and
-        # pointing "inwards", i.e. towards the center point of the parent cylinder
-        # TODO Check that this works properly!
-        return self.reference_vector     # from testInteractionSingle; reference vector always points from the
-                                         # particle position projected onto the target surface towards particle pos.
+        # Here we assume implicitly that the cap and the
+        # rod are collinear
+        return self.target_structure.shape.unit_z
 
     def get_searchpoint(self):
         return self.pid_particle_pair[1].position

--- a/shells.py
+++ b/shells.py
@@ -188,7 +188,7 @@ class testInteractionSingle(testSingle, Others):
         self.particle_surface_distance = self.world.distance(self.target_structure.shape, self.pid_particle_pair[1].position)
 
         # The reference_vector is the normalized vector from the reference_point to the particle
-        if pos_transposed != self.reference_point :
+        if any(pos_transposed != self.reference_point) :
             self.reference_vector = normalize(pos_transposed - self.reference_point)
         else:
             self.reference_vector = 0

--- a/shells.py
+++ b/shells.py
@@ -1701,6 +1701,7 @@ class DiskSurfaceSingletestShell(CylindricaltestShell, testNonInteractionSingle)
         # - dz_left stays constant and is equal to the cap-bound particle radius
         # - dz_right can be scaled, minimum is set accordingly
         # - dr stays constant and is determined by the maximal particle radius involved
+        #   plus the rod radius (particle unbinds perpendicularly to disk normal vector)
         self.dzdr_right = numpy.inf
         self.drdz_right = 0.0
         self.r0_right   = self.pid_particle_pair[1].radius
@@ -1713,11 +1714,11 @@ class DiskSurfaceSingletestShell(CylindricaltestShell, testNonInteractionSingle)
         # sizing up the shell to a zero shell
         self.dz_right = self.pid_particle_pair[1].radius
         self.dz_left  = self.pid_particle_pair[1].radius
-        self.dr       = self.pid_particle_pair[1].radius        
+        self.dr       = self.pid_particle_pair[1].radius + self.structure.shape.radius
 
     def get_orientation_vector(self):
         return self.structure.shape.unit_z
-        # just copy from disk structure; note that this defines the direction of dissociation!        
+        # just copy from disk structure
 
     def get_searchpoint(self):
         return self.pid_particle_pair[1].position
@@ -1727,14 +1728,14 @@ class DiskSurfaceSingletestShell(CylindricaltestShell, testNonInteractionSingle)
 
     def get_min_dr_dzright_dzleft(self):
         # TODO This will never be called, right? Why do dz_right/dz_left have value larger than particle_radius?
-        dr       = self.pid_particle_pair[1].radius
+        dr       = self.dr
         dz_right = self.pid_particle_pair[1].radius * math.sqrt(MULTI_SHELL_FACTOR**2 - 1.0) #  TODO Use SINGLE_SHELL_FACTOR instead?
         dz_left  = dz_right
         return dr, dz_right, dz_left
         
     def get_max_dr_dzright_dzleft(self):
         # Radius is not scaled here so we do not to check for distance to shape edge
-        dr       = self.pid_particle_pair[1].radius
+        dr       = self.dr
         dz_right = self.pid_particle_pair[1].radius * math.sqrt(MULTI_SHELL_FACTOR**2 - 1.0) # same as the minimum, i.e. no scaling of this length
         dz_left  = dz_right
         return dr, dz_right, dz_left


### PR DESCRIPTION
Several fixes and polishing of structure interactions and unbindings in both BD and eGFRD modes.

Among others:
- Plane binding/unbinding is now one-sided by default, but can be made double-sided as an option
- For that purpose planes now have a property is_one_sided (=true by default)
- Fixed erroneous reaction firing in cases where a particle overlaps with both another particle and a surface
- the makefile now has a flag that filters out shared object linking errors
- ...
