### PR TITLE
Turn off MixedPair2D3D formation again after merging confusion...

### DIFF
--- a/egfrd.py
+++ b/egfrd.py
@@ -143,10 +143,10 @@ def try_default_testpair(single1, single2, geometrycontainer, domains):
             return CylindricalSurfacePairtestShell  (single1, single2, geometrycontainer, domains)
     elif (isinstance(single1.structure, PlanarSurface) and isinstance(single2.structure, PlanarSurface)):
         return PlanarSurfaceTransitionPairtestShell (single1, single2, geometrycontainer, domains) 
-    elif (isinstance(single1.structure, PlanarSurface) and isinstance(single2.structure, CuboidalRegion)):
-        return MixedPair2D3DtestShell               (single1, single2, geometrycontainer, domains) 
-    elif (isinstance(single2.structure, PlanarSurface) and isinstance(single1.structure, CuboidalRegion)):
-        return MixedPair2D3DtestShell(single2, single1, geometrycontainer, domains)
+    #elif (isinstance(single1.structure, PlanarSurface) and isinstance(single2.structure, CuboidalRegion)):
+        #return MixedPair2D3DtestShell               (single1, single2, geometrycontainer, domains) 
+    #elif (isinstance(single2.structure, PlanarSurface) and isinstance(single1.structure, CuboidalRegion)):
+        #return MixedPair2D3DtestShell(single2, single1, geometrycontainer, domains)
     elif (isinstance(single1.structure, CylindricalSurface) and isinstance(single2.structure, DiskSurface)):
         return MixedPair1DCaptestShell(single1, single2, geometrycontainer, domains)
     elif (isinstance(single2.structure, CylindricalSurface) and isinstance(single1.structure, DiskSurface)):


### PR DESCRIPTION
This turns off the formation of MixedPair2D3D until the issues with cylinder scaling are fixed here.
