### PR TITLE
Update for backward compatibilty (GCC < v4.8)

### DIFF
--- a/CuboidalRegion.hpp
+++ b/CuboidalRegion.hpp
@@ -111,7 +111,7 @@ public:
     
     // Vector used to determine whether a particle has crossed the structure
     // Here we return the zero-vector because there is no "sides" to cross
-    virtual position_type const& side_comparison_vector() const
+    virtual position_type const side_comparison_vector() const
     {
         return create_vector<position_type>(0.0, 0.0, 0.0);
     }

--- a/Cylinder.hpp
+++ b/Cylinder.hpp
@@ -180,7 +180,7 @@ inline typename Cylinder<T_>::length_type
 distance(Cylinder<T_> const& obj,
                 typename Cylinder<T_>::position_type const& pos)
 {
-    typedef typename Cylinder<T_>::position_type position_type;
+  //typedef typename Cylinder<T_>::position_type position_type;
     typedef typename Cylinder<T_>::length_type length_type;
 
     /* First compute the (r,z) components of pos in a coordinate system 

--- a/CylindricalBesselGenerator.hpp
+++ b/CylindricalBesselGenerator.hpp
@@ -11,9 +11,6 @@
 
 class CylindricalBesselGenerator
 {
-
-    typedef UnsignedInteger Index;
-
 public:
 
     CylindricalBesselGenerator()

--- a/CylindricalSurface.hpp
+++ b/CylindricalSurface.hpp
@@ -136,7 +136,7 @@ public:
     
     // Vector used to determine whether a particle has crossed the structure
     // Here we return the zero-vector because there is no "sides" to cross
-    virtual position_type const& side_comparison_vector() const
+    virtual position_type const side_comparison_vector() const
     {
         return create_vector<position_type>(0.0, 0.0, 0.0);
     }

--- a/Defs.hpp
+++ b/Defs.hpp
@@ -6,21 +6,11 @@
 typedef double Real;
 typedef long int Integer;
 typedef unsigned long int UnsignedInteger;
-typedef size_t Index;
 
-// stringifiers.  see preprocessor manual
-#define XSTR( S ) STR( S )
 #define STR( S ) #S
-
-#define THROW_UNLESS( CLASS, EXPRESSION )       \
-    if( ! ( EXPRESSION ) )\
-    {\
-        throw CLASS( "Check [" + std::string( STR( EXPRESSION ) ) +\
-                     "] failed." );\
-    }\
-
-
-#define IGNORE_RETURN (void)
+#define THROW_UNLESS( CLASS, EXPRESSION )\
+    if(!(EXPRESSION))\
+      throw CLASS("Check ["+std::string(STR(EXPRESSION)) + "] failed.");
 
 const Real SEPARATION_TOLERANCE( 1e-07  );
 const Real MINIMAL_SEPARATION_FACTOR( 1.0 + SEPARATION_TOLERANCE );

--- a/Disk.hpp
+++ b/Disk.hpp
@@ -171,7 +171,7 @@ inline typename Disk<T_>::length_type
 distance(Disk<T_> const& obj,
                 typename Disk<T_>::position_type const& pos)
 {
-    typedef typename Disk<T_>::position_type position_type;
+  //typedef typename Disk<T_>::position_type position_type;
     typedef typename Disk<T_>::length_type length_type;
 
     /* First compute the (r,z) components of pos in a coordinate system 

--- a/DiskSurface.hpp
+++ b/DiskSurface.hpp
@@ -150,7 +150,7 @@ public:
     
     // Vector used to determine whether a particle has crossed the structure
     // Here we return the zero-vector because there is no "sides" to cross
-    virtual position_type const& side_comparison_vector() const
+    virtual position_type const side_comparison_vector() const
     {
         return create_vector<position_type>(0.0, 0.0, 0.0);
     }

--- a/EGFRDSimulator.hpp
+++ b/EGFRDSimulator.hpp
@@ -2331,9 +2331,6 @@ protected:
     template<typename Tshell>
     void determine_next_event(AnalyticalSingle<traits_type, Tshell>& domain)
     {
-        typedef Tshell shell_type;
-        typedef typename shell_type::shape_type shape_type;
-        typedef typename detail::get_greens_function<shape_type>::type greens_function;
         time_type const dt_reaction(draw_single_reaction_time(domain.particle().second.sid()));
         time_type const dt_escape_or_interaction(draw_escape_or_interaction_time(domain));
         LOG_DEBUG(("determine_next_event: %s => dt_reaction=%.16g, "
@@ -2454,7 +2451,6 @@ protected:
     void restore_domain(AnalyticalSingle<traits_type, T>& domain,
                         std::pair<domain_id_type, length_type> const& closest)
     {
-        typedef typename AnalyticalSingle<traits_type, T>::shell_type shell_type;
         domain_type const* closest_domain(
             closest.second == std::numeric_limits<length_type>::infinity() ?
                 (domain_type const*)0: get_domain(closest.first).get());
@@ -3202,8 +3198,6 @@ protected:
     template<typename T>
     void fire_event(AnalyticalPair<traits_type, T>& domain, pair_event_kind kind)
     {
-        typedef AnalyticalSingle<traits_type, T> corresponding_single_type;
-
         if (kind == PAIR_EVENT_IV_UNDETERMINED)
         {
             // Draw actual pair event for iv at very last minute.

--- a/GreensFunction1DRadAbs.hpp
+++ b/GreensFunction1DRadAbs.hpp
@@ -262,12 +262,11 @@ private:
     uint guess_maxi( Real const& t ) const;
 
     /* this is the appropriate definition of the function in gsl. */
-    static double tan_f (double x, void *p);
-
+    static Real tan_f (Real x, void *p);
 
     /* functions for drawTime / p_survival */
 
-    static double drawT_f (double t, void *p);
+    static Real drawT_f (Real t, void *p);
 
     Real p_survival_table( Real  t, RealVector& psurvTable ) const;
 

--- a/GreensFunction2DAbsSym.cpp
+++ b/GreensFunction2DAbsSym.cpp
@@ -244,7 +244,7 @@ GreensFunction2DAbsSym::drawR( const Real rnd, const Real t ) const
         return 0.0;
     }
 
-    const Real thresholdDistance( this->CUTOFF_H * sqrt( 4.0 * D * t ) );
+    //const Real thresholdDistance( this->CUTOFF_H * sqrt( 4.0 * D * t ) );
 
     gsl_function F;
     Real psurv;

--- a/GreensFunction2DRadAbs.cpp
+++ b/GreensFunction2DRadAbs.cpp
@@ -121,13 +121,13 @@ GreensFunction2DRadAbs::f_alpha0( const Real alpha ) const
     // Needed? TODO
 //  const Real h_s( h * sigma);
 
-    const double J0_s_An (gsl_sf_bessel_J0(s_An));
-    const double J1_s_An (gsl_sf_bessel_J1(s_An));
-    const double J0_a_An (gsl_sf_bessel_J0(a_An));
+    const Real J0_s_An (gsl_sf_bessel_J0(s_An));
+    const Real J1_s_An (gsl_sf_bessel_J1(s_An));
+    const Real J0_a_An (gsl_sf_bessel_J0(a_An));
 
-    const double Y0_s_An (gsl_sf_bessel_Y0(s_An));
-    const double Y1_s_An (gsl_sf_bessel_Y1(s_An));
-    const double Y0_a_An (gsl_sf_bessel_Y0(a_An));	
+    const Real Y0_s_An (gsl_sf_bessel_Y0(s_An));
+    const Real Y1_s_An (gsl_sf_bessel_Y1(s_An));
+    const Real Y0_a_An (gsl_sf_bessel_Y0(a_An));	
 
 //  const double rho1 ( ( (h_s * J0_s_An) + (s_An * J1_s_An) ) * Y0_a_An );
 //  const double rho2 ( ( (h_s * Y0_s_An) + (s_An * Y1_s_An) ) * J0_a_An );
@@ -135,8 +135,8 @@ GreensFunction2DRadAbs::f_alpha0( const Real alpha ) const
 
     // Sigma can be divided out, roots will remain same:
     // (Note: actually double checked this).
-    const double rho1 ( ( (h * J0_s_An) + (alpha * J1_s_An) ) * Y0_a_An );
-    const double rho2 ( ( (h * Y0_s_An) + (alpha * Y1_s_An) ) * J0_a_An );
+    const Real rho1 ( ( (h * J0_s_An) + (alpha * J1_s_An) ) * Y0_a_An );
+    const Real rho2 ( ( (h * Y0_s_An) + (alpha * Y1_s_An) ) * J0_a_An );
 
     return rho1 - rho2;
 }
@@ -172,16 +172,16 @@ const Real GreensFunction2DRadAbs::f_alpha( const Real alpha,
     const Real realn( static_cast<Real>( n ) );
     const Real h_sigma( h * sigma);
 
-    const double Jn_s_An (gsl_sf_bessel_Jn(n,s_An));
-    const double Jn1_s_An (gsl_sf_bessel_Jn(n+1,s_An));
-    const double Jn_a_An (gsl_sf_bessel_Jn(n,a_An));
+    const Real Jn_s_An (gsl_sf_bessel_Jn(n,s_An));
+    const Real Jn1_s_An (gsl_sf_bessel_Jn(n+1,s_An));
+    const Real Jn_a_An (gsl_sf_bessel_Jn(n,a_An));
 
-    const double Yn_s_An (gsl_sf_bessel_Yn(n,s_An));
-    const double Yn1_s_An (gsl_sf_bessel_Yn(n+1,s_An));
-    const double Yn_a_An (gsl_sf_bessel_Yn(n,a_An));
+    const Real Yn_s_An (gsl_sf_bessel_Yn(n,s_An));
+    const Real Yn1_s_An (gsl_sf_bessel_Yn(n+1,s_An));
+    const Real Yn_a_An (gsl_sf_bessel_Yn(n,a_An));
 
-    const double rho1 ( ( (h_sigma * Jn_s_An) + (s_An * Jn1_s_An) - realn*Jn_s_An ) * Yn_a_An );
-    const double rho2 ( ( (h_sigma * Yn_s_An) + (s_An * Yn1_s_An) - realn*Yn_s_An ) * Jn_a_An );
+    const Real rho1 ( ( (h_sigma * Jn_s_An) + (s_An * Jn1_s_An) - realn*Jn_s_An ) * Yn_a_An );
+    const Real rho2 ( ( (h_sigma * Yn_s_An) + (s_An * Yn1_s_An) - realn*Yn_s_An ) * Jn_a_An );
     return (rho1 - rho2); 
 
 //  Or..?
@@ -842,10 +842,10 @@ GreensFunction2DRadAbs::p_survival_table( const        Real t,
           
     if( psurvTable.size() < maxi + 1 )           // if the dimensions are good then this means
     {                                            // that the table is filled
-        IGNORE_RETURN getAlpha( 0, maxi );       // this updates the table of roots
-            this->createPsurvTable( psurvTable); // then the table is filled with data
+       getAlpha( 0, maxi );                      // this updates the table of roots
+       this->createPsurvTable( psurvTable);      // then the table is filled with data
     }
-    // A sum over terms is performed, where convergence is assumed. It is not 
+        // A sum over terms is performed, where convergence is assumed. It is not 
     // clear if this is a just assumption.
     // TODO!
     p = funcSum_all( boost::bind( &GreensFunction2DRadAbs::p_survival_i_exp_table,
@@ -1674,7 +1674,7 @@ Real GreensFunction2DRadAbs::givePDFR( const Real r, const Real t ) const
             return r0;
     }
 
-    const Real psurv( p_survival( t ) ); // calculate the survival probability at this time
+    p_survival(t); // calculate the survival probability at this time
                                          // this is used as the normalization factor
                                          // BEWARE!!! This also produces the roots An and therefore
                                          // SETS THE HIGHEST INDEX -> side effect

--- a/GreensFunction3DRadAbs.cpp
+++ b/GreensFunction3DRadAbs.cpp
@@ -1171,7 +1171,7 @@ GreensFunction3DRadAbs::p_survival_table(Real t, RealVector& psurvTable) const
             
             if (psurvTable.size() < maxi + 1)
             {
-                IGNORE_RETURN getAlpha0(maxi);  // this updates the table
+                getAlpha0(maxi);  // this updates the table
                 this->createPsurvTable(psurvTable);
             }
 
@@ -1270,10 +1270,10 @@ struct p_survival_params
     const Real rnd;
 };
 
-static Real p_survival_F(Real t, p_survival_params const* params)
-{
-    return params->rnd - params->gf->p_survival(t);
-}
+//NOT USED static Real p_survival_F(Real t, p_survival_params const* params)
+//{
+//    return params->rnd - params->gf->p_survival(t);
+//}
 
 struct p_survival_2i_params
 { 
@@ -1281,11 +1281,11 @@ struct p_survival_2i_params
     const Real t;
 };
 
-static Real p_survival_2i_F(Real ri, p_survival_2i_params const* params)
-{
-    return params->gf->p_survival_2i_exp(static_cast<unsigned int>(ri),
-                                         params->t);
-}
+//NOT USED static Real p_survival_2i_F(Real ri, p_survival_2i_params const* params)
+//{
+//    return params->gf->p_survival_2i_exp(static_cast<unsigned int>(ri),
+//                                         params->t);
+//}
 
 struct p_survival_i_alpha_params
 { 
@@ -1293,11 +1293,11 @@ struct p_survival_i_alpha_params
     const Real t;
 };
 
-static Real p_survival_i_alpha_F(Real alpha,
-                                 p_survival_i_alpha_params const* params)
-{
-    return params->gf->p_survival_i_alpha(alpha, params->t);
-}
+//NOT USED static Real p_survival_i_alpha_F(Real alpha,
+//                                 p_survival_i_alpha_params const* params)
+//{
+//    return params->gf->p_survival_i_alpha(alpha, params->t);
+//}
 
 struct p_leave_params
 { 
@@ -1636,7 +1636,7 @@ GreensFunction3DRadAbs::drawPleaves(gsl_function const& F,
     }
     else
     {
-        Real low_value_prev(value);
+        //Real low_value_prev(value);
         low *= .1;
 
         for (;;)
@@ -1661,7 +1661,7 @@ GreensFunction3DRadAbs::drawPleaves(gsl_function const& F,
                           minT, low, GSL_FN_EVAL(&F, low), r0, dump().c_str());
                 return minT;
             }
-            low_value_prev = low_value;
+            //low_value_prev = low_value;
 
             log_.info("drawTime2: adjusting low: %.16g, Fs = %.16g", low, low_value);
             low *= .1;

--- a/GreensFunction3DRadInf.cpp
+++ b/GreensFunction3DRadInf.cpp
@@ -490,7 +490,7 @@ Real GreensFunction3DRadInf::ip_corr_n(unsigned int n, RealVector const& RnTable
 
 Real GreensFunction3DRadInf::p_corr_table(Real theta, Real r, Real t, RealVector const& RnTable) const
 {
-    const Index tableSize(RnTable.size());
+    const size_t tableSize(RnTable.size());
     if(tableSize == 0)
     {
         return 0.0;
@@ -524,7 +524,7 @@ Real GreensFunction3DRadInf::p_corr_table(Real theta, Real r, Real t, RealVector
 Real GreensFunction3DRadInf::ip_corr_table(Real theta, Real r,
                                             Real t, RealVector const& RnTable) const
 {
-    const Index tableSize(RnTable.size());
+    const size_t tableSize(RnTable.size());
     if(tableSize == 0)
     {
         return 0.0;

--- a/Multi.hpp
+++ b/Multi.hpp
@@ -814,11 +814,7 @@ public:
        
     void step()
     {
-        boost::scoped_ptr<
-            typename multi_particle_container_type::transaction_type>
-                tx(pc_.create_transaction());
-        typedef typename multi_particle_container_type::transaction_type::particle_id_pair_generator particle_id_pair_generator;
-        typedef typename multi_particle_container_type::transaction_type::particle_id_pair_and_distance_list particle_id_pair_and_distance_list;
+        boost::scoped_ptr<typename multi_particle_container_type::transaction_type> tx(pc_.create_transaction());  
         last_reaction_setter rs(*this);
         volume_clearer vc(*this);
         

--- a/ParticleContainerBase.hpp
+++ b/ParticleContainerBase.hpp
@@ -246,7 +246,7 @@ public:
         typename element_type_of<T1_>::type const& D1,
         typename element_type_of<T1_>::type const& D2)
     {
-        typedef typename element_type_of< T1_ >::type element_type;   
+      //typedef typename element_type_of< T1_ >::type element_type;   
 
         T1_ retval;
 

--- a/PlanarSurface.hpp
+++ b/PlanarSurface.hpp
@@ -132,7 +132,7 @@ public:
     
     // Vector used to determine whether a particle has crossed the structure
     // For the plane the normal vector is the natural choice
-    virtual position_type const& side_comparison_vector() const
+    virtual position_type const side_comparison_vector() const
     {
         return base_type::shape().unit_z();
     }

--- a/Plane.hpp
+++ b/Plane.hpp
@@ -429,7 +429,7 @@ template<typename T, typename Trng>
 inline typename Plane<T>::position_type
 random_position(Plane<T> const& shape, Trng& rng)
 {
-    typedef typename Plane<T>::length_type length_type;
+  //typedef typename Plane<T>::length_type length_type;
 
     // -1 < rng() < 1. See for example PlanarSurface.hpp.
     return add(

--- a/SphericalBesselGenerator.hpp
+++ b/SphericalBesselGenerator.hpp
@@ -12,9 +12,6 @@
 
 class SphericalBesselGenerator
 {
-
-    typedef UnsignedInteger Index;
-
 public:
 
     SphericalBesselGenerator()

--- a/SphericalSurface.hpp
+++ b/SphericalSurface.hpp
@@ -89,7 +89,7 @@ public:
     
     // Vector used to determine whether a particle has crossed the structure
     // Here we return the zero-vector because there is no "sides" to cross
-    virtual position_type const& side_comparison_vector() const
+    virtual position_type const side_comparison_vector() const
     {
         return create_vector<position_type>(0.0, 0.0, 0.0);
     }

--- a/Structure.hpp
+++ b/Structure.hpp
@@ -140,8 +140,8 @@ public:
     virtual projected_type project_point(position_type const& pos) const = 0;
     virtual projected_type project_point_on_surface(position_type const& pos) const = 0;
     virtual length_type distance(position_type const& pos) const = 0;
-    virtual position_type const& position() const = 0;
-    virtual position_type const& side_comparison_vector() const = 0;
+    virtual position_type const& position() const = 0;      
+    virtual position_type const side_comparison_vector() const = 0;
 
     // Methods used for edge crossing (only for the planes so far)
     virtual position_flag_pair_type deflect(position_type const& pos0, position_type const& displacement) const = 0;

--- a/StructureContainer.hpp
+++ b/StructureContainer.hpp
@@ -450,7 +450,7 @@ apply_boundary (std::pair<typename Ttraits_::position_type,
     typedef typename plane_type::position_type              vector_type;
 
     typedef std::pair<structure_id_type, position_type>     neighbor_id_vector_type;
-    typedef std::pair<position_type, structure_id_type>     position_structid_pair_type;
+    //typedef std::pair<position_type, structure_id_type>     position_structid_pair_type;
 
     // Note that we assume that the new position is in the plane (dot(pos, unit_z)==0)
     // and that the position is already transposed for the plane.
@@ -469,7 +469,8 @@ apply_boundary (std::pair<typename Ttraits_::position_type,
     
     // info variables
     bool planes_are_orthogonal( false );
-    bool planes_are_parallel( false );    
+
+    //bool planes_are_parallel( false );    
     
     // Check for (currently unsupported) self-connections
     for( int i=0; i<4; i++ )
@@ -505,7 +506,7 @@ apply_boundary (std::pair<typename Ttraits_::position_type,
                 new_id = neighbor_id_vector.first;
                 
                 if(neighbor_id_vector.second == zero_vector)
-                    planes_are_parallel = true;
+		  ;//planes_are_parallel = true;
                 else{
                     planes_are_orthogonal = true;
                     neighbor_plane_par = multiply(origin_plane.unit_x(), component_x);
@@ -521,7 +522,7 @@ apply_boundary (std::pair<typename Ttraits_::position_type,
                 new_id = neighbor_id_vector.first;
                 
                 if(neighbor_id_vector.second == zero_vector)
-                    planes_are_parallel = true;
+		  ;//planes_are_parallel = true;
                 else{
                     planes_are_orthogonal = true;
                     neighbor_plane_par = multiply(origin_plane.unit_x(), component_x);
@@ -539,7 +540,7 @@ apply_boundary (std::pair<typename Ttraits_::position_type,
 
                 new_id = neighbor_id_vector.first;
                 if(neighbor_id_vector.second == zero_vector)
-                    planes_are_parallel = true;
+		  ;//planes_are_parallel = true;
                 else{
                     planes_are_orthogonal = true;
                     neighbor_plane_par = multiply(origin_plane.unit_y(), component_y);
@@ -554,7 +555,7 @@ apply_boundary (std::pair<typename Ttraits_::position_type,
 
                 new_id = neighbor_id_vector.first;
                 if(neighbor_id_vector.second == zero_vector)
-                    planes_are_parallel = true;
+		  ;//planes_are_parallel = true;
                 else{
                     planes_are_orthogonal = true;
                     neighbor_plane_par = multiply(origin_plane.unit_y(), component_y);

--- a/StructureFunctions.hpp
+++ b/StructureFunctions.hpp
@@ -57,9 +57,9 @@ get_pos_sid_pair( CuboidalRegion<Ttraits_>              const& origin_structure,
                   typename Ttraits_::length_type        const& reaction_length,
                   typename Ttraits_::rng_type           &rng              )
 {
-    typedef typename Ttraits_::structure_id_type        structure_id_type;
-    typedef typename Ttraits_::position_type            position_type;
-    typedef typename Ttraits_::length_type              length_type;
+  //typedef typename Ttraits_::structure_id_type        structure_id_type;
+  //typedef typename Ttraits_::position_type            position_type;
+  //typedef typename Ttraits_::length_type              length_type;
     
     // Currently only species change and decay are supported
     if(origin_structure.id() == target_structure.id()){
@@ -83,7 +83,7 @@ get_pos_sid_pair( CuboidalRegion<Ttraits_>              const& origin_structure,
 {
     typedef typename Ttraits_::structure_id_type        structure_id_type;
     typedef typename Ttraits_::position_type            position_type;
-    typedef typename Ttraits_::length_type              length_type;
+    //typedef typename Ttraits_::length_type              length_type;
 
     /*** COMBINATION NOT SUPPORTED ***/
     throw illegal_propagation_attempt("Structure transition between combination of origin structure and target structure not supported (CuboidalRegion->Sphere).");
@@ -191,7 +191,7 @@ get_pos_sid_pair( SphericalSurface<Ttraits_>            const& origin_structure,
 {
     typedef typename Ttraits_::structure_id_type        structure_id_type;
     typedef typename Ttraits_::position_type            position_type;
-    typedef typename Ttraits_::length_type              length_type;
+    //typedef typename Ttraits_::length_type              length_type;
 
     /*** COMBINATION NOT SUPPORTED ***/
     throw illegal_propagation_attempt("Structure transition between combination of origin structure and target structure not supported (Sphere->CuboidalRegion).");
@@ -211,7 +211,7 @@ get_pos_sid_pair( SphericalSurface<Ttraits_>            const& origin_structure,
 {
     typedef typename Ttraits_::structure_id_type        structure_id_type;
     typedef typename Ttraits_::position_type            position_type;
-    typedef typename Ttraits_::length_type              length_type;
+    //typedef typename Ttraits_::length_type              length_type;
 
     /*** COMBINATION NOT SUPPORTED ***/
     throw illegal_propagation_attempt("Structure transition between combination of origin structure and target structure not supported (Sphere->Sphere).");
@@ -231,7 +231,7 @@ get_pos_sid_pair( SphericalSurface<Ttraits_>            const& origin_structure,
 {
     typedef typename Ttraits_::structure_id_type        structure_id_type;
     typedef typename Ttraits_::position_type            position_type;
-    typedef typename Ttraits_::length_type              length_type;
+    //typedef typename Ttraits_::length_type              length_type;
 
     /*** COMBINATION NOT SUPPORTED ***/
     throw illegal_propagation_attempt("Structure transition between combination of origin structure and target structure not supported (Sphere->Cylinder).");
@@ -251,7 +251,7 @@ get_pos_sid_pair( SphericalSurface<Ttraits_>            const& origin_structure,
 {
     typedef typename Ttraits_::structure_id_type        structure_id_type;
     typedef typename Ttraits_::position_type            position_type;
-    typedef typename Ttraits_::length_type              length_type;
+    //typedef typename Ttraits_::length_type              length_type;
 
     /*** COMBINATION NOT SUPPORTED ***/
     throw illegal_propagation_attempt("Structure transition between combination of origin structure and target structure not supported (Sphere->Disk).");
@@ -271,7 +271,7 @@ get_pos_sid_pair( SphericalSurface<Ttraits_>            const& origin_structure,
 {
     typedef typename Ttraits_::structure_id_type        structure_id_type;
     typedef typename Ttraits_::position_type            position_type;
-    typedef typename Ttraits_::length_type              length_type;
+    //typedef typename Ttraits_::length_type              length_type;
 
     /*** COMBINATION NOT SUPPORTED ***/
     throw illegal_propagation_attempt("Structure transition between combination of origin structure and target structure not supported (Sphere->Plane).");
@@ -292,9 +292,9 @@ get_pos_sid_pair( CylindricalSurface<Ttraits_>          const& origin_structure,
                   typename Ttraits_::length_type        const& reaction_length,
                   typename Ttraits_::rng_type           &rng              )
 {
-    typedef typename Ttraits_::structure_id_type        structure_id_type;
+  //typedef typename Ttraits_::structure_id_type        structure_id_type;
     typedef typename Ttraits_::position_type            position_type;
-    typedef typename Ttraits_::length_type              length_type;
+    //typedef typename Ttraits_::length_type              length_type;
     
     position_type displacement( origin_structure.surface_dissociation_vector(rng, offset, reaction_length) );
     position_type new_pos( add(old_pos, displacement) );    
@@ -313,9 +313,9 @@ get_pos_sid_pair( CylindricalSurface<Ttraits_>          const& origin_structure,
                   typename Ttraits_::length_type        const& reaction_length,
                   typename Ttraits_::rng_type           &rng              )
 {
-    typedef typename Ttraits_::structure_id_type        structure_id_type;
-    typedef typename Ttraits_::position_type            position_type;
-    typedef typename Ttraits_::length_type              length_type;
+  //typedef typename Ttraits_::structure_id_type        structure_id_type;
+  //typedef typename Ttraits_::position_type            position_type;
+  //typedef typename Ttraits_::length_type              length_type;
 
     // Currently only species change and decay are supported
     if(origin_structure.id() == target_structure.id()){
@@ -339,7 +339,7 @@ get_pos_sid_pair( CylindricalSurface<Ttraits_>          const& origin_structure,
 {
     typedef typename Ttraits_::structure_id_type        structure_id_type;
     typedef typename Ttraits_::position_type            position_type;
-    typedef typename Ttraits_::length_type              length_type;
+    //typedef typename Ttraits_::length_type              length_type;
 
     /*** COMBINATION NOT SUPPORTED ***/
     throw illegal_propagation_attempt("Structure transition between combination of origin structure and target structure not supported (Cylinder->Sphere).");
@@ -428,9 +428,9 @@ get_pos_sid_pair( DiskSurface<Ttraits_>                 const& origin_structure,
                   typename Ttraits_::length_type        const& reaction_length,
                   typename Ttraits_::rng_type           &rng              )
 {
-    typedef typename Ttraits_::structure_id_type        structure_id_type;
+  //typedef typename Ttraits_::structure_id_type        structure_id_type;
     typedef typename Ttraits_::position_type            position_type;
-    typedef typename Ttraits_::length_type              length_type;
+    //typedef typename Ttraits_::length_type              length_type;
     
     // Here offset should be the radius of the product species
     
@@ -453,7 +453,7 @@ get_pos_sid_pair( DiskSurface<Ttraits_>                 const& origin_structure,
 {
     typedef typename Ttraits_::structure_id_type        structure_id_type;
     typedef typename Ttraits_::position_type            position_type;
-    typedef typename Ttraits_::length_type              length_type;
+    //typedef typename Ttraits_::length_type              length_type;
 
     /*** COMBINATION NOT SUPPORTED ***/
     throw illegal_propagation_attempt("Structure transition between combination of origin structure and target structure not supported (Disk->Sphere).");
@@ -471,9 +471,9 @@ get_pos_sid_pair( DiskSurface<Ttraits_>                 const& origin_structure,
                   typename Ttraits_::length_type        const& reaction_length,
                   typename Ttraits_::rng_type           &rng              )
 {
-    typedef typename Ttraits_::structure_id_type        structure_id_type;
+  //typedef typename Ttraits_::structure_id_type        structure_id_type;
     typedef typename Ttraits_::position_type            position_type;
-    typedef typename Ttraits_::length_type              length_type;
+    //typedef typename Ttraits_::length_type              length_type;
 
     position_type u( origin_structure.surface_dissociation_unit_vector(rng) );
     
@@ -498,9 +498,9 @@ get_pos_sid_pair( DiskSurface<Ttraits_>                 const& origin_structure,
                   typename Ttraits_::length_type        const& reaction_length,
                   typename Ttraits_::rng_type           &rng              )
 {
-    typedef typename Ttraits_::structure_id_type        structure_id_type;
-    typedef typename Ttraits_::position_type            position_type;
-    typedef typename Ttraits_::length_type              length_type;
+  //typedef typename Ttraits_::structure_id_type        structure_id_type;
+  //typedef typename Ttraits_::position_type            position_type;
+  //typedef typename Ttraits_::length_type              length_type;
 
     // Currently only species change and decay are supported
     if(origin_structure.id() == target_structure.id()){
@@ -522,9 +522,9 @@ get_pos_sid_pair( DiskSurface<Ttraits_>                 const& origin_structure,
                   typename Ttraits_::length_type        const& reaction_length,
                   typename Ttraits_::rng_type           &rng              )
 {
-    typedef typename Ttraits_::structure_id_type        structure_id_type;
+  //typedef typename Ttraits_::structure_id_type        structure_id_type;
     typedef typename Ttraits_::position_type            position_type;
-    typedef typename Ttraits_::length_type              length_type;
+    //typedef typename Ttraits_::length_type              length_type;
 
     // Treated in the same way as unbinding from disk to bulk (see above)
     // Here offset should be the radius of the product species
@@ -549,9 +549,9 @@ get_pos_sid_pair( PlanarSurface<Ttraits_>               const& origin_structure,
                   typename Ttraits_::length_type        const& reaction_length,
                   typename Ttraits_::rng_type           &rng              )
 {
-    typedef typename Ttraits_::structure_id_type        structure_id_type;
+  //typedef typename Ttraits_::structure_id_type        structure_id_type;
     typedef typename Ttraits_::position_type            position_type;
-    typedef typename Ttraits_::length_type              length_type;
+    //typedef typename Ttraits_::length_type              length_type;
 
     position_type displacement( origin_structure.surface_dissociation_vector(rng, offset, reaction_length) );
     position_type new_pos( add(old_pos, displacement) );
@@ -572,7 +572,7 @@ get_pos_sid_pair( PlanarSurface<Ttraits_>               const& origin_structure,
 {
     typedef typename Ttraits_::structure_id_type        structure_id_type;
     typedef typename Ttraits_::position_type            position_type;
-    typedef typename Ttraits_::length_type              length_type;
+    //typedef typename Ttraits_::length_type              length_type;
 
     /*** COMBINATION NOT SUPPORTED ***/
     throw illegal_propagation_attempt("Structure transition between combination of origin structure and target structure not supported (Plane->Sphere).");
@@ -592,7 +592,7 @@ get_pos_sid_pair( PlanarSurface<Ttraits_>               const& origin_structure,
 {
     typedef typename Ttraits_::structure_id_type        structure_id_type;
     typedef typename Ttraits_::position_type            position_type;
-    typedef typename Ttraits_::length_type              length_type;
+    //typedef typename Ttraits_::length_type              length_type;
 
     /*** COMBINATION NOT SUPPORTED ***/
     throw illegal_propagation_attempt("Structure transition between combination of origin structure and target structure not supported (Plane->Cylinder).");
@@ -645,7 +645,7 @@ get_pos_sid_pair( PlanarSurface<Ttraits_>               const& origin_structure,
                   typename Ttraits_::length_type        const& reaction_length,
                   typename Ttraits_::rng_type           &rng              )
 {
-    typedef typename Ttraits_::structure_id_type          structure_id_type;
+  //typedef typename Ttraits_::structure_id_type          structure_id_type;
     typedef typename Ttraits_::position_type              position_type;
     typedef typename Ttraits_::length_type                length_type;
     typedef std::pair<length_type, length_type>           length_pair_type;
@@ -719,7 +719,7 @@ get_pos_sid_pair_pair( CuboidalRegion<Ttraits_>               const& origin_stru
 {
     typedef typename Ttraits_::structure_id_type        structure_id_type;
     typedef typename Ttraits_::position_type            position_type;
-    typedef typename Ttraits_::length_type              length_type;
+    //typedef typename Ttraits_::length_type              length_type;
 
     // Currently we do not allow for pair forward/backward reactions between two different cubes
     if(origin_structure.id() == target_structure.id()){
@@ -752,7 +752,7 @@ get_pos_sid_pair_pair( CuboidalRegion<Ttraits_>               const& origin_stru
 {
     typedef typename Ttraits_::structure_id_type        structure_id_type;
     typedef typename Ttraits_::position_type            position_type;
-    typedef typename Ttraits_::length_type              length_type;
+    //typedef typename Ttraits_::length_type              length_type;
 
     /*** COMBINATION NOT SUPPORTED ***/
     throw illegal_propagation_attempt("Structure transition between combination of origin structure and target structure not supported (CuboidalRegion->CuboidalRegion/Sphere).");
@@ -775,7 +775,7 @@ get_pos_sid_pair_pair( CuboidalRegion<Ttraits_>               const& origin_stru
 {
     typedef typename Ttraits_::structure_id_type        structure_id_type;
     typedef typename Ttraits_::position_type            position_type;
-    typedef typename Ttraits_::length_type              length_type;
+    //typedef typename Ttraits_::length_type              length_type;
 
     /*** COMBINATION NOT SUPPORTED ***/
     throw illegal_propagation_attempt("Structure transition between combination of origin structure and target structure not supported (CuboidalRegion->CuboidalRegion/Cylinder).");
@@ -799,7 +799,7 @@ get_pos_sid_pair_pair( CuboidalRegion<Ttraits_>               const& origin_stru
 {
     typedef typename Ttraits_::structure_id_type        structure_id_type;
     typedef typename Ttraits_::position_type            position_type;
-    typedef typename Ttraits_::length_type              length_type;
+    //typedef typename Ttraits_::length_type              length_type;
 
     /*** COMBINATION NOT SUPPORTED ***/
     throw illegal_propagation_attempt("Structure transition between combination of origin structure and target structure not supported (CuboidalRegion->CuboidalRegion/Disk).");
@@ -822,7 +822,7 @@ get_pos_sid_pair_pair( CuboidalRegion<Ttraits_>               const& origin_stru
 {
     typedef typename Ttraits_::structure_id_type        structure_id_type;
     typedef typename Ttraits_::position_type            position_type;
-    typedef typename Ttraits_::length_type              length_type;
+    //typedef typename Ttraits_::length_type              length_type;
 
     /*** COMBINATION NOT SUPPORTED ***/
     throw illegal_propagation_attempt("Structure transition between combination of origin structure and target structure not supported (CuboidalRegion->CuboidalRegion/Plane).");
@@ -848,7 +848,7 @@ get_pos_sid_pair_pair( SphericalSurface<Ttraits_>             const& origin_stru
 {
     typedef typename Ttraits_::structure_id_type        structure_id_type;
     typedef typename Ttraits_::position_type            position_type;
-    typedef typename Ttraits_::length_type              length_type;
+    //typedef typename Ttraits_::length_type              length_type;
 
     /*** COMBINATION NOT SUPPORTED ***/
     throw illegal_propagation_attempt("Structure transition between combination of origin structure and target structure not supported (Sphere->Sphere/CuboidalRegion).");
@@ -871,7 +871,7 @@ get_pos_sid_pair_pair( SphericalSurface<Ttraits_>             const& origin_stru
 {
     typedef typename Ttraits_::structure_id_type        structure_id_type;
     typedef typename Ttraits_::position_type            position_type;
-    typedef typename Ttraits_::length_type              length_type;
+    //typedef typename Ttraits_::length_type              length_type;
 
     /*** COMBINATION NOT SUPPORTED ***/
     throw illegal_propagation_attempt("Structure transition between combination of origin structure and target structure not supported (Sphere->Sphere/Sphere).");
@@ -894,7 +894,7 @@ get_pos_sid_pair_pair( SphericalSurface<Ttraits_>             const& origin_stru
 {
     typedef typename Ttraits_::structure_id_type        structure_id_type;
     typedef typename Ttraits_::position_type            position_type;
-    typedef typename Ttraits_::length_type              length_type;
+    //typedef typename Ttraits_::length_type              length_type;
 
     /*** COMBINATION NOT SUPPORTED ***/
     throw illegal_propagation_attempt("Structure transition between combination of origin structure and target structure not supported (Sphere->Sphere/Cylinder).");
@@ -917,7 +917,7 @@ get_pos_sid_pair_pair( SphericalSurface<Ttraits_>             const& origin_stru
 {
     typedef typename Ttraits_::structure_id_type        structure_id_type;
     typedef typename Ttraits_::position_type            position_type;
-    typedef typename Ttraits_::length_type              length_type;
+    //typedef typename Ttraits_::length_type              length_type;
 
     /*** COMBINATION NOT SUPPORTED ***/
     throw illegal_propagation_attempt("Structure transition between combination of origin structure and target structure not supported (Sphere->Sphere/Disk).");
@@ -940,7 +940,7 @@ get_pos_sid_pair_pair( SphericalSurface<Ttraits_>             const& origin_stru
 {
     typedef typename Ttraits_::structure_id_type        structure_id_type;
     typedef typename Ttraits_::position_type            position_type;
-    typedef typename Ttraits_::length_type              length_type;
+    //typedef typename Ttraits_::length_type              length_type;
 
     /*** COMBINATION NOT SUPPORTED ***/
     throw illegal_propagation_attempt("Structure transition between combination of origin structure and target structure not supported (Sphere->Sphere/Plane).");
@@ -964,9 +964,9 @@ get_pos_sid_pair_pair( CylindricalSurface<Ttraits_>           const& origin_stru
                        typename Ttraits_::length_type         const& reaction_length,
                        typename Ttraits_::rng_type            &rng                )
 {
-    typedef typename Ttraits_::structure_id_type        structure_id_type;
+  //typedef typename Ttraits_::structure_id_type        structure_id_type;
     typedef typename Ttraits_::position_type            position_type;
-    typedef typename Ttraits_::length_type              length_type;
+    //typedef typename Ttraits_::length_type              length_type;
 
     std::pair<position_type, position_type> new_positions( origin_structure.special_geminate_dissociation_positions(rng, s_orig, s_targ, old_pos, reaction_length) );
     // special_geminate_dissociation_positions will produce two new positions close to old_pos taking into account
@@ -993,7 +993,7 @@ get_pos_sid_pair_pair( CylindricalSurface<Ttraits_>           const& origin_stru
 {
     typedef typename Ttraits_::structure_id_type        structure_id_type;
     typedef typename Ttraits_::position_type            position_type;
-    typedef typename Ttraits_::length_type              length_type;
+    //typedef typename Ttraits_::length_type              length_type;
 
     // Currently we do not allow for pair forward/backward reactions between two different cylinders
     if(origin_structure.id() == target_structure.id()){
@@ -1026,7 +1026,7 @@ get_pos_sid_pair_pair( CylindricalSurface<Ttraits_>           const& origin_stru
 {
     typedef typename Ttraits_::structure_id_type        structure_id_type;
     typedef typename Ttraits_::position_type            position_type;
-    typedef typename Ttraits_::length_type              length_type;
+    //typedef typename Ttraits_::length_type              length_type;
 
     /*** COMBINATION NOT SUPPORTED ***/
     throw illegal_propagation_attempt("Structure transition between combination of origin structure and target structure not supported (Cylinder->Cylinder/Sphere).");
@@ -1049,7 +1049,7 @@ get_pos_sid_pair_pair( CylindricalSurface<Ttraits_>           const& origin_stru
 {
     typedef typename Ttraits_::structure_id_type        structure_id_type;
     typedef typename Ttraits_::position_type            position_type;
-    typedef typename Ttraits_::length_type              length_type;
+    //typedef typename Ttraits_::length_type              length_type;
 
     /*** COMBINATION NOT SUPPORTED ***/
     throw illegal_propagation_attempt("Structure transition between combination of origin structure and target structure not supported (Cylinder->Cylinder/Disk).");
@@ -1072,7 +1072,7 @@ get_pos_sid_pair_pair( CylindricalSurface<Ttraits_>           const& origin_stru
 {
     typedef typename Ttraits_::structure_id_type        structure_id_type;
     typedef typename Ttraits_::position_type            position_type;
-    typedef typename Ttraits_::length_type              length_type;
+    //typedef typename Ttraits_::length_type              length_type;
 
     /*** COMBINATION NOT SUPPORTED ***/
     throw illegal_propagation_attempt("Structure transition between combination of origin structure and target structure not supported (Cylinder->Cylinder/Plane).");
@@ -1096,9 +1096,9 @@ get_pos_sid_pair_pair( DiskSurface<Ttraits_>                  const& origin_stru
                        typename Ttraits_::length_type         const& reaction_length,
                        typename Ttraits_::rng_type            &rng                )
 {
-    typedef typename Ttraits_::structure_id_type        structure_id_type;
+  //typedef typename Ttraits_::structure_id_type        structure_id_type;
     typedef typename Ttraits_::position_type            position_type;
-    typedef typename Ttraits_::length_type              length_type;
+    //typedef typename Ttraits_::length_type              length_type;
 
     std::pair<position_type, position_type> new_positions( origin_structure.special_geminate_dissociation_positions(rng, s_orig, s_targ, old_pos, reaction_length) );
     // special_geminate_dissociation_positions will produce two new positions close to old_pos taking into account
@@ -1125,7 +1125,7 @@ get_pos_sid_pair_pair( DiskSurface<Ttraits_>                  const& origin_stru
 {
     typedef typename Ttraits_::structure_id_type        structure_id_type;
     typedef typename Ttraits_::position_type            position_type;
-    typedef typename Ttraits_::length_type              length_type;
+    //typedef typename Ttraits_::length_type              length_type;
 
     /*** COMBINATION NOT SUPPORTED ***/
     throw illegal_propagation_attempt("Structure transition between combination of origin structure and target structure not supported (Disk->Disk/Sphere).");
@@ -1148,7 +1148,7 @@ get_pos_sid_pair_pair( DiskSurface<Ttraits_>                  const& origin_stru
 {
     typedef typename Ttraits_::structure_id_type        structure_id_type;
     typedef typename Ttraits_::position_type            position_type;
-    typedef typename Ttraits_::length_type              length_type;
+    //typedef typename Ttraits_::length_type              length_type;
 
     // TODO TODO TODO
     // IMPLEMENT THE UNBINDING FROM THE DISK ACTING AS A SINK!
@@ -1174,7 +1174,7 @@ get_pos_sid_pair_pair( DiskSurface<Ttraits_>                  const& origin_stru
 {
     typedef typename Ttraits_::structure_id_type        structure_id_type;
     typedef typename Ttraits_::position_type            position_type;
-    typedef typename Ttraits_::length_type              length_type;
+    //typedef typename Ttraits_::length_type              length_type;
 
     /*** COMBINATION NOT SUPPORTED ***/
     throw illegal_propagation_attempt("Structure transition between combination of origin structure and target structure not supported (Disk->Disk/Disk).");
@@ -1195,9 +1195,9 @@ get_pos_sid_pair_pair( DiskSurface<Ttraits_>                  const& origin_stru
                        typename Ttraits_::length_type         const& reaction_length,
                        typename Ttraits_::rng_type            &rng                )
 {
-    typedef typename Ttraits_::structure_id_type        structure_id_type;
+  //typedef typename Ttraits_::structure_id_type        structure_id_type;
     typedef typename Ttraits_::position_type            position_type;
-    typedef typename Ttraits_::length_type              length_type;
+    //typedef typename Ttraits_::length_type              length_type;
 
     std::pair<position_type, position_type> new_positions( origin_structure.special_geminate_dissociation_positions(rng, s_orig, s_targ, old_pos, reaction_length) );
     // special_geminate_dissociation_positions will produce two new positions close to old_pos taking into account
@@ -1226,7 +1226,7 @@ get_pos_sid_pair_pair( PlanarSurface<Ttraits_>                const& origin_stru
                        typename Ttraits_::length_type         const& reaction_length,
                        typename Ttraits_::rng_type            &rng                )
 {
-    typedef typename Ttraits_::structure_id_type        structure_id_type;
+  //typedef typename Ttraits_::structure_id_type        structure_id_type;
     typedef typename Ttraits_::position_type            position_type;
     typedef typename Ttraits_::length_type              length_type;
     
@@ -1271,7 +1271,7 @@ get_pos_sid_pair_pair( PlanarSurface<Ttraits_>                const& origin_stru
 {
     typedef typename Ttraits_::structure_id_type        structure_id_type;
     typedef typename Ttraits_::position_type            position_type;
-    typedef typename Ttraits_::length_type              length_type;
+    //typedef typename Ttraits_::length_type              length_type;
 
     /*** COMBINATION NOT SUPPORTED ***/
     throw illegal_propagation_attempt("Structure transition between combination of origin structure and target structure not supported (Plane->Plane/Sphere).");
@@ -1294,7 +1294,7 @@ get_pos_sid_pair_pair( PlanarSurface<Ttraits_>                const& origin_stru
 {
     typedef typename Ttraits_::structure_id_type        structure_id_type;
     typedef typename Ttraits_::position_type            position_type;
-    typedef typename Ttraits_::length_type              length_type;
+    //typedef typename Ttraits_::length_type              length_type;
 
     /*** COMBINATION NOT SUPPORTED ***/
     throw illegal_propagation_attempt("Structure transition between combination of origin structure and target structure not supported (Plane->Plane/Cylinder).");
@@ -1317,7 +1317,7 @@ get_pos_sid_pair_pair( PlanarSurface<Ttraits_>                const& origin_stru
 {
     typedef typename Ttraits_::structure_id_type        structure_id_type;
     typedef typename Ttraits_::position_type            position_type;
-    typedef typename Ttraits_::length_type              length_type;
+    //typedef typename Ttraits_::length_type              length_type;
 
     /*** COMBINATION NOT SUPPORTED ***/
     throw illegal_propagation_attempt("Structure transition between combination of origin structure and target structure not supported (Plane->Plane/Disk).");
@@ -1340,7 +1340,7 @@ get_pos_sid_pair_pair( PlanarSurface<Ttraits_>                const& origin_stru
 {
     typedef typename Ttraits_::structure_id_type        structure_id_type;
     typedef typename Ttraits_::position_type            position_type;
-    typedef typename Ttraits_::length_type              length_type;
+    //typedef typename Ttraits_::length_type              length_type;
 
     // As a default we produce two new positions on the same plane; in principle the particles can end up
     // on different planes, but this should be treated afterwards via apply_boundary.

--- a/World.hpp
+++ b/World.hpp
@@ -333,7 +333,7 @@ public:
     void add_species(species_type const& species)
     {
         // make sure that the structure_type defined in the species exists
-        structure_type_type const& structure_type(get_structure_type(species.structure_type_id()));
+        //structure_type_type const& structure_type(get_structure_type(species.structure_type_id()));
 
         species_map_[species.id()] = species;
         particle_pool_[species.id()] = particle_id_set();
@@ -363,7 +363,8 @@ public:
             particle_pool_.find(sid));
         if (i == particle_pool_.end())
         {
-            throw not_found(std::string("Unknown species (id=") + boost::lexical_cast<std::string>(sid) + ")");
+
+	  throw not_found(std::string("Unknown species (id=") + boost::lexical_cast<std::string>(sid) + ")");
         }
         return (*i).second;
     }
@@ -373,8 +374,8 @@ public:
     template <typename Tstructure_>
     structure_id_type add_structure(boost::shared_ptr<Tstructure_> structure)
     {
-        // check that the structure_type that is defined in the structure exists!
-        structure_type_type const& structure_type(get_structure_type(structure->sid()));
+           // check that the structure_type that is defined in the structure exists!
+      //structure_type_type const& structure_type(get_structure_type(structure->sid()));
 
         const structure_id_type structure_id(structidgen_());
         structure->set_id(structure_id);
@@ -477,7 +478,7 @@ public:
         }
 
         // check that the structure_type that is defined in the structure exists!
-        structure_type_type const& structure_type(get_structure_type(cuboidal_region->sid()));
+        //structure_type_type const& structure_type(get_structure_type(cuboidal_region->sid()));
 
         cuboidal_region->set_id(default_struct_id);
         update_structure(std::make_pair(default_struct_id, cuboidal_region));

--- a/binding/MatrixSpace.hpp
+++ b/binding/MatrixSpace.hpp
@@ -80,7 +80,7 @@ struct MatrixSpaceExtrasBase
         {
             static PyObject* convert(const result_type& val)
             {
-                const npy_intp dims[1] = { val.size() };
+ 	        const npy_intp dims[1] = { static_cast<const npy_intp>(val.size()) };
                 boost::python::incref(reinterpret_cast<PyObject*>(result_type_descr_));
                 PyObject* retval = PyArray_NewFromDescr(&PyArray_Type,
                         result_type_descr_,

--- a/binding/Particle.hpp
+++ b/binding/Particle.hpp
@@ -162,7 +162,7 @@ public:
     static PyObject* get_position(ParticleWrapper* self)
     {
         typename Timpl_::position_type const& pos(self->impl_.position());
-        const npy_intp dims[1] = { boost::size(pos) };
+        const npy_intp dims[1] = { static_cast<const npy_intp>(boost::size(pos)) };
         PyObject* retval = PyArray_New(&PyArray_Type, 1,
                 const_cast<npy_intp*>(dims),
                 peer::util::get_numpy_typecode<typename Timpl_::length_type>::value,

--- a/binding/module_functions.cpp
+++ b/binding/module_functions.cpp
@@ -15,8 +15,6 @@ calculate_pair_CoM(Position const& p1,
                    element_type_of< Position >::type const& D2,
                    element_type_of< Position >::type const& world_size)
 {
-    typedef element_type_of<Position>::type element_type;   
-
     Position retval;
 
     const Position p2t(cyclic_transpose<Position>(p2, p1, world_size));

--- a/configure.ac
+++ b/configure.ac
@@ -35,7 +35,7 @@ else
 fi
 AC_SUBST(DEBUG)
 
-CXXFLAGS="$CXXFLAGS -Wall -Wno-unused-local-typedefs"
+CXXFLAGS="$CXXFLAGS -Wall"
 
 AX_BOOST_BASE([1.37],,AC_MSG_ERROR([could not find required version of BOOST.]))
 

--- a/freeFunctions.cpp
+++ b/freeFunctions.cpp
@@ -616,7 +616,7 @@ Real I_bd_1D(Real sigma, Real t, Real D, Real v)
 
     const Real Dt4(4 * D * t);
     const Real sqrt4Dt(std::sqrt(Dt4));
-    double vt = v*t;
+    Real vt = v*t;
 
     const Real arg1(-(2*sigma + vt)*(2*sigma + vt)/Dt4);
     const Real term1(expl( -vt*vt/Dt4 ) - expl( arg1 ));

--- a/peer/wrappers/range/stl_container_wrapper.hpp
+++ b/peer/wrappers/range/stl_container_wrapper.hpp
@@ -189,7 +189,6 @@ public:
         }
         catch (boost::python::error_already_set const&)
         {
-            return NULL;
         }
         return 0;
     }

--- a/utils/map_adapter.hpp
+++ b/utils/map_adapter.hpp
@@ -2,7 +2,7 @@
 #define MAP_ADAPTER_HPP
 
 #include <utility>
-#include "utils.hpp"
+//#include "utils.hpp"
 #include <boost/range/size.hpp>
 #include <boost/range/begin.hpp>
 #include <boost/range/end.hpp>


### PR DESCRIPTION
Compiler flag 'no-unused-local-typedefs' is not known before GCC v4.8. 
This incorrectly make the Amolf Cluster fail on the ./configure test for Boost. 

Later commits actually removed the codelines generating the warning, so the disable waring flag is no longer needed anymore.
